### PR TITLE
fix(mcp): bind on [::] dual-stack + boot println diagnostics (#22)

### DIFF
--- a/crates/trios-railway-mcp/src/main.rs
+++ b/crates/trios-railway-mcp/src/main.rs
@@ -20,7 +20,7 @@
 
 mod tools;
 
-use std::net::SocketAddr;
+use std::net::{Ipv6Addr, SocketAddr};
 
 use anyhow::{Context, Result};
 use rmcp::transport::streamable_http_server::{
@@ -32,11 +32,18 @@ use crate::tools::TriosRailwayMcp;
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    // Pre-tracing diagnostic line so Railway captures *something* even if
+    // the env filter swallows tracing output. R5 honesty: never silent.
+    println!(
+        "[trios-railway-mcp] boot: pid={}, exe ok",
+        std::process::id()
+    );
+
     tracing_subscriber::fmt()
         .with_env_filter(
             EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
         )
-        .with_writer(std::io::stderr)
+        .with_writer(std::io::stdout)
         .compact()
         .init();
 
@@ -44,9 +51,12 @@ async fn main() -> Result<()> {
         .ok()
         .and_then(|p| p.parse().ok())
         .unwrap_or(8080);
-    let addr: SocketAddr = SocketAddr::from(([0, 0, 0, 0], port));
+    // Bind on IPv6 unspecified (`[::]`) so the Railway private-network proxy
+    // (IPv6-only) can reach us. Linux dual-stack also accepts IPv4 here.
+    let addr: SocketAddr = SocketAddr::from((Ipv6Addr::UNSPECIFIED, port));
 
     tracing::info!(%addr, "trios-railway-mcp starting");
+    println!("[trios-railway-mcp] binding to {addr}");
 
     let mcp = StreamableHttpService::new(
         || Ok(TriosRailwayMcp::new()),


### PR DESCRIPTION
Closes #22

Container boots but Railway proxy returns 502 with no app logs. App was binding on IPv4 `0.0.0.0:$PORT` while Railway private-network ingress is IPv6-only.

Fix:
- Bind on `[::]:$PORT` (Ipv6Addr::UNSPECIFIED). Linux dual-stack accepts IPv4 on the same socket.
- Pre-tracing `println!` boot line so Railway captures something before tracing init.
- Tracing writer: stderr -> stdout.

Verified locally on debug + release: `curl http://127.0.0.1:PORT/healthz` and `http://[::1]:PORT/healthz` both return 200.

R-rules: R1 (Rust-only), R5, R7.