### PR TITLE
feat(audit): tri-railway audit run + verdict CLI (closes #9, refs #143)

### DIFF
--- a/bin/tri-railway/src/main.rs
+++ b/bin/tri-railway/src/main.rs
@@ -320,7 +320,8 @@ async fn load_ledger(path: &std::path::Path) -> Result<Vec<LedgerRow>> {
 /// Best-effort seed extraction from a service name like `trios-train-seed-43`
 /// or `igla-final-seed-44`.
 fn seed_from_name(name: &str) -> Option<i32> {
-    name.rsplit_once("seed-").and_then(|(_, tail)| tail.parse::<i32>().ok())
+    name.rsplit_once("seed-")
+        .and_then(|(_, tail)| tail.parse::<i32>().ok())
 }
 
 async fn run_audit(
@@ -330,8 +331,8 @@ async fn run_audit(
     json_out: bool,
     root: PathBuf,
 ) -> Result<i32> {
-    let client = Client::from_env()
-        .map_err(|e| anyhow::anyhow!("RAILWAY_TOKEN not set or invalid: {e}"))?;
+    let client =
+        Client::from_env().map_err(|e| anyhow::anyhow!("RAILWAY_TOKEN not set or invalid: {e}"))?;
     let token_fp = client.token_fingerprint();
 
     let pid = ProjectId::from(project);

--- a/bin/tri-railway/src/main.rs
+++ b/bin/tri-railway/src/main.rs
@@ -16,7 +16,9 @@ use anyhow::Result;
 use clap::{Parser, Subcommand};
 use std::path::PathBuf;
 
-use trios_railway_audit::migrations;
+use trios_railway_audit::{
+    detect, migrations, verdict as compute_verdict, AuditVerdict, LedgerRow, RealService,
+};
 use trios_railway_core::{
     mutations as M, queries as Q, Client, EnvironmentId, ProjectId, RailwayHash, ServiceId,
 };
@@ -125,6 +127,38 @@ enum ServiceCmd {
 enum AuditCmd {
     /// Print idempotent DDL for the Neon schema (issue #6).
     MigrateSql,
+    /// Run an online audit pass: list services, detect drift, compute Gate-2
+    /// verdict, seal an R7 triplet to the experience log. Exit codes:
+    /// 0 = Gate-2 PASS, 1 = drift detected (error severity), 2 = NOT YET.
+    Run {
+        /// Project to audit.
+        #[arg(long, env = "TRIOS_RAILWAY_PROJECT", default_value = IGLA_PROJECT_ID)]
+        project: String,
+        /// Gate-2 BPB target (Gate-2 = 1.85, IGLA = 1.50).
+        #[arg(long, default_value_t = 1.85_f64)]
+        target: f64,
+        /// Optional path to a JSONL ledger (one `LedgerRow`-like JSON per line).
+        /// If omitted, audit treats the ledger as empty and any seed-bearing
+        /// service will surface as `D1_ORPHAN_SERVICE` (warn, not error).
+        #[arg(long)]
+        ledger: Option<PathBuf>,
+        /// Print the verdict as JSON to stdout (in addition to text summary).
+        #[arg(long)]
+        json: bool,
+        /// Repo root for the experience log.
+        #[arg(long, default_value = ".")]
+        root: PathBuf,
+    },
+    /// Compute Gate-2 verdict against an in-memory ledger snapshot. Useful
+    /// for cron jobs that already have a Neon snapshot serialized to JSONL.
+    Verdict {
+        /// Path to a JSONL ledger.
+        #[arg(long)]
+        ledger: PathBuf,
+        /// Gate-2 BPB target.
+        #[arg(long, default_value_t = 1.85_f64)]
+        target: f64,
+    },
 }
 
 #[derive(Subcommand, Debug)]
@@ -195,6 +229,25 @@ async fn main() -> Result<()> {
                 println!("{stmt};");
             }
         }
+        Cmd::Audit {
+            sub:
+                AuditCmd::Run {
+                    project,
+                    target,
+                    ledger,
+                    json,
+                    root,
+                },
+        } => {
+            let exit = run_audit(project, target, ledger, json, root).await?;
+            std::process::exit(exit);
+        }
+        Cmd::Audit {
+            sub: AuditCmd::Verdict { ledger, target },
+        } => {
+            let exit = cmd_audit_verdict(ledger, target).await?;
+            std::process::exit(exit);
+        }
         Cmd::Service { sub } => run_service(sub).await?,
         Cmd::Experience { sub } => match sub {
             ExperienceCmd::Append {
@@ -223,6 +276,169 @@ async fn main() -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Parse a JSONL ledger file into `LedgerRow`s. Unrecognised lines are
+/// skipped with a warn-level trace. Empty path -> empty vec.
+async fn load_ledger(path: &std::path::Path) -> Result<Vec<LedgerRow>> {
+    let raw = tokio::fs::read_to_string(path).await?;
+    let mut out = Vec::new();
+    for (i, line) in raw.lines().enumerate() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        match serde_json::from_str::<serde_json::Value>(line) {
+            Ok(v) => {
+                let seed = v.get("seed").and_then(serde_json::Value::as_i64);
+                let bpb = v.get("bpb").and_then(serde_json::Value::as_f64);
+                let digest = v
+                    .get("canonical_image_digest")
+                    .or_else(|| v.get("image_digest"))
+                    .and_then(serde_json::Value::as_str)
+                    .map(str::to_string);
+                if let (Some(seed), Some(bpb)) = (seed, bpb) {
+                    let Ok(seed_i32) = i32::try_from(seed) else {
+                        tracing::warn!(line_no = i + 1, seed, "seed out of i32 range");
+                        continue;
+                    };
+                    out.push(LedgerRow {
+                        seed: seed_i32,
+                        bpb,
+                        canonical_image_digest: digest,
+                    });
+                } else {
+                    tracing::warn!(line_no = i + 1, "ledger row missing seed/bpb");
+                }
+            }
+            Err(e) => tracing::warn!(line_no = i + 1, ?e, "ledger row not valid JSON"),
+        }
+    }
+    Ok(out)
+}
+
+/// Best-effort seed extraction from a service name like `trios-train-seed-43`
+/// or `igla-final-seed-44`.
+fn seed_from_name(name: &str) -> Option<i32> {
+    name.rsplit_once("seed-").and_then(|(_, tail)| tail.parse::<i32>().ok())
+}
+
+async fn run_audit(
+    project: String,
+    target: f64,
+    ledger_path: Option<PathBuf>,
+    json_out: bool,
+    root: PathBuf,
+) -> Result<i32> {
+    let client = Client::from_env()
+        .map_err(|e| anyhow::anyhow!("RAILWAY_TOKEN not set or invalid: {e}"))?;
+    let token_fp = client.token_fingerprint();
+
+    let pid = ProjectId::from(project);
+    let pv = Q::project_view(&client, &pid).await?;
+
+    let real: Vec<RealService> = pv
+        .services()
+        .into_iter()
+        .map(|s| RealService {
+            service_id: ServiceId::from(s.id.clone()),
+            seed: seed_from_name(&s.name),
+            name: s.name,
+            last_log_excerpt: None,
+            last_bpb: None,
+            image_digest: None,
+        })
+        .collect();
+
+    let ledger = match ledger_path.as_deref() {
+        Some(p) => load_ledger(p).await?,
+        None => Vec::new(),
+    };
+
+    let events = detect(&real, &ledger);
+    let v = compute_verdict(&real, &events, target);
+
+    println!("project {} ({})", pv.name, pv.id);
+    println!("services: {}   ledger rows: {}", real.len(), ledger.len());
+    println!("target BPB:   {target}");
+    println!("drift events: {}", events.len());
+    for e in &events {
+        println!("  [{:?}] {:?} {}", e.severity, e.code, e.detail);
+    }
+    let label = match v {
+        AuditVerdict::Gate2Pass => "GATE-2 PASS",
+        AuditVerdict::NotYet => "NOT YET",
+        AuditVerdict::Drift => "DRIFT",
+    };
+    println!("verdict: {label}  (exit {})", v.exit_code());
+
+    if json_out {
+        let summary = serde_json::json!({
+            "project":      pv.id,
+            "project_name": pv.name,
+            "services":     real.len(),
+            "ledger_rows":  ledger.len(),
+            "target":       target,
+            "events":       events,
+            "verdict":      label,
+            "exit_code":    v.exit_code(),
+        });
+        println!("{summary}");
+    }
+
+    // R7 triplet for the audit pass itself.
+    let hash = RailwayHash::seal("audit", &pid, None, &token_fp);
+    let line = ExperienceLine::from_hash(
+        "GENERAL",
+        "DriftDoc",
+        "#9",
+        &format!(
+            "audit run target={target} services={} events={} verdict={label}",
+            real.len(),
+            events.len()
+        ),
+        match v {
+            AuditVerdict::Gate2Pass => "OK",
+            AuditVerdict::NotYet => "WAIT",
+            AuditVerdict::Drift => "FAIL",
+        },
+        "VERDICT",
+        &hash,
+    )?;
+    let path = append_line(&root.join(".trinity"), &line).await?;
+    tracing::info!(experience = %path.display(), "audit triplet sealed");
+
+    Ok(v.exit_code())
+}
+
+async fn cmd_audit_verdict(ledger_path: PathBuf, target: f64) -> Result<i32> {
+    let ledger = load_ledger(&ledger_path).await?;
+    // synthetic real services with one entry per ledger seed,
+    // pretending Railway reality matches the ledger 1:1.
+    let real: Vec<RealService> = ledger
+        .iter()
+        .map(|r| RealService {
+            service_id: ServiceId::from(format!("ledger-seed-{}", r.seed)),
+            name: format!("trios-train-seed-{}", r.seed),
+            seed: Some(r.seed),
+            last_log_excerpt: None,
+            last_bpb: Some(r.bpb),
+            image_digest: None,
+        })
+        .collect();
+    let events = detect(&real, &ledger);
+    let v = compute_verdict(&real, &events, target);
+    println!(
+        "verdict: {}  (rows={}, target={target}, exit={})",
+        match v {
+            AuditVerdict::Gate2Pass => "GATE-2 PASS",
+            AuditVerdict::NotYet => "NOT YET",
+            AuditVerdict::Drift => "DRIFT",
+        },
+        ledger.len(),
+        v.exit_code()
+    );
+    Ok(v.exit_code())
 }
 
 fn parse_var(s: &str) -> Result<(String, String)> {

--- a/crates/trios-railway-core/src/transport.rs
+++ b/crates/trios-railway-core/src/transport.rs
@@ -87,13 +87,14 @@ struct GraphQlError {
 impl Client {
     pub fn from_env() -> Result<Self, ClientError> {
         let token = std::env::var("RAILWAY_TOKEN").map_err(|_| ClientError::MissingToken)?;
-        // Heuristic: a UUID-shaped token (8-4-4-4-12, length 36) is
-        // overwhelmingly a project-access token in Railway. Account/team
-        // tokens are longer, opaque, and start with `rwt_` or similar.
-        let auth = if is_uuid_like(&token) {
-            AuthMode::Project
-        } else {
-            AuthMode::Team
+        // Allow operators to force the auth mode when the heuristic guesses
+        // wrong (Personal API tokens are also UUID-shaped but must use
+        // `Authorization: Bearer`, not `Project-Access-Token`).
+        let auth = match std::env::var("RAILWAY_TOKEN_AUTH").ok().as_deref() {
+            Some("team" | "bearer" | "personal") => AuthMode::Team,
+            Some("project") => AuthMode::Project,
+            _ if is_uuid_like(&token) => AuthMode::Project,
+            _ => AuthMode::Team,
         };
         Self::with_token_and_mode(token, auth)
     }


### PR DESCRIPTION
## Summary

Closes [#9](https://github.com/gHashTag/trios-railway/issues/9). Refs [trios#143](https://github.com/gHashTag/trios/issues/143) (Gate-2 / L-R14).

Adds the online-audit subcommands that formally close **L-R14**
(Gate-2 verdict) with deterministic exit codes:

```
tri-railway audit run     --project <UUID> --target <BPB> [--ledger PATH] [--json]
tri-railway audit verdict --ledger PATH    --target <BPB>
```

Anchor: `phi^2 + phi^-2 = 3`.

## What it does

- **`audit run`** lists Railway services via `Q::project_view`, parses
  seed numbers from names like `trios-train-seed-43` or `igla-final-seed-44`,
  optionally loads a JSONL ledger, calls `trios_railway_audit::detect`
  (full D1..D7 drift detection — already in tree from issue #7),
  runs `verdict()` to compute `Gate2Pass / NotYet / Drift`, prints a
  text summary, optionally JSON, then seals an R7 audit triplet to
  `.trinity/experience` via the existing `trios-railway-experience`
  writer.
- **`audit verdict`** is the offline form for cron/CI: takes a JSONL
  ledger snapshot already serialized from Neon, computes the same
  verdict against synthetic services, exits with the same codes.

### Exit codes (deterministic)

| Code | Meaning | Trigger |
|---|---|---|
| `0` | GATE-2 PASS | ≥3 services with `bpb < target`, no error-severity drift |
| `1` | DRIFT       | any error-severity event (D3, D4, D5) |
| `2` | NOT YET     | no errors, target not yet met |

## Auth bug fix in `trios-railway-core`

The UUID-shape heuristic in `Client::from_env` was treating Personal API
tokens (also UUID-shaped) as project-access tokens, sending them via the
`Project-Access-Token` header instead of `Authorization: Bearer`.
This made the live IGLA project return `Not Authorized` even with a valid
token.

Fix: add `RAILWAY_TOKEN_AUTH` env override (`team` / `bearer` / `personal`
→ Bearer; `project` → Project-Access-Token; default = old heuristic).
Verified with both curl variants against `backboard.railway.com/graphql/v2`.

## R5-honest verification (local)

```
cargo build  --bin tri-railway --locked   → OK (42s clean, 1.5s incremental)
cargo test   --workspace --locked          → 22 passed, 0 failed
cargo clippy --workspace -D warnings       → 0 warnings, 0 errors
```

### Live smoke against IGLA project (Acc1 token, e4fe33bb-...)

```
$ RAILWAY_TOKEN=<acc1> RAILWAY_TOKEN_AUTH=team \
    tri-railway audit run --project e4fe33bb-... --target 1.85
project IGLA (e4fe33bb-3b09-4842-9782-7d2dea1abc9b)
services: 18   ledger rows: 0
target BPB:   1.85
drift events: 16
  [Warn] D1OrphanService {"msg":"no ledger row","service":"trios-train-seed-100"}
  [Warn] D1OrphanService {"msg":"no ledger row","service":"igla-final-seed-44"}
  ... (14 more)
verdict: NOT YET  (exit 2)
INFO audit triplet sealed experience=.trinity/experience/trios_railway_20260427.trinity
```

R7 triplet that was actually sealed:

```json
{
  "ts":"2026-04-27T14:50:04Z",
  "agent":"GENERAL","soul_name":"DriftDoc","issue":"#9","phi_step":"VERDICT",
  "task":"audit run target=1.85 services=18 events=16 verdict=NOT YET",
  "status":"WAIT",
  "triplet":"RAIL=audit @ project=e4fe33bb service=- sha=6d1428a48dcf3c18 ts=2026-04-27T14:50:04Z"
}
```

### Synthetic ledger smokes (3-way verdict)

```
$ tri-railway audit verdict --ledger pass.jsonl --target 1.85
verdict: GATE-2 PASS  (rows=3, target=1.85, exit=0)         # exit 0 ✅

$ tri-railway audit verdict --ledger pass.jsonl --target 1.50
verdict: NOT YET  (rows=3, target=1.5, exit=2)              # exit 2 ✅

$ tri-railway audit verdict --ledger overflow.jsonl --target 1.85
verdict: DRIFT  (rows=1, target=1.85, exit=1)               # exit 1 ✅ (D5_OVERFLOW)
```

## How #143 uses this

The cron watchdog ([#16](https://github.com/gHashTag/trios-railway/issues/16))
runs hourly:

```bash
tri-railway audit run \
    --project "$RAILWAY_PROJECT_ACC1_IGLA" \
    --target 1.85 \
    --ledger /tmp/igla-ledger.jsonl \
    --json | gh issue comment 143 --repo gHashTag/trios --body-file -

case $? in
  0) gh issue close 143 --reason completed --comment "GATE-2 PASS" ;;
  1) gh issue comment 143 --body "DRIFT — investigate" ;;
  2) ;;  # NOT YET — keep training
esac
```

This is the deterministic closure path for issue #143.

## Follow-ups (not in this PR)

- Issue [#8](https://github.com/gHashTag/trios-railway/issues/8): Neon
  writer for `audit_event` rows (this PR loads ledger from JSONL,
  next PR writes drift events back into Neon `railway_audit_events`).
- Issue [#16](https://github.com/gHashTag/trios-railway/issues/16): wire
  this CLI into a cron task that comments on `trios#143` every hour.
- Issue [#17](https://github.com/gHashTag/trios-railway/issues/17): expose
  `audit_run` as an MCP tool so `trios-perplexity` can drive verdicts.

φ² + φ⁻² = 3 | TRINITY | NEVER STOP