### PR TITLE
feat(watchdog): hourly audit cron posting digest to trios#143 (closes #16)

### DIFF
--- a/.github/workflows/audit-watchdog.yml
+++ b/.github/workflows/audit-watchdog.yml
@@ -1,0 +1,152 @@
+name: IGLA Audit Watchdog (hourly)
+
+# Closes issue #16. Anchor: phi^2 + phi^-2 = 3.
+# Runs `tri-railway audit run` every hour against both clusters
+# (Acc1/IGLA + Acc2/IGLA-MIRROR-2), posts a one-line digest as a comment
+# on trios#143, and routes by exit code:
+#   0 = GATE-2 PASS  -> close #143 (L-R14)
+#   1 = DRIFT        -> red status comment + workflow fails
+#   2 = NOT YET      -> green digest comment, workflow passes
+
+on:
+  schedule:
+    - cron: "5 * * * *"          # 5 minutes past every hour, UTC
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "BPB target. Gate-2 = 1.85, IGLA = 1.50"
+        required: false
+        default: "1.85"
+      skip_comment:
+        description: "If 'true', do not comment on trios#143 (dry run)"
+        required: false
+        default: "false"
+
+permissions:
+  contents: read
+  issues:   write   # cross-repo comment on trios#143
+
+concurrency:
+  group: audit-watchdog
+  cancel-in-progress: false
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      TARGET:                ${{ inputs.target || '1.85' }}
+      ACC1_TOKEN:            ${{ secrets.RAILWAY_TOKEN_ACC1 }}
+      ACC1_PROJECT:          ${{ secrets.RAILWAY_PROJECT_ACC1_IGLA }}
+      ACC2_TOKEN:            ${{ secrets.RAILWAY_TOKEN_ACC2 }}
+      ACC2_PROJECT:          ${{ secrets.RAILWAY_PROJECT_ACC2_TE }}
+      RAILWAY_TOKEN_AUTH:    team
+      RUST_LOG:              info
+      GH_TOKEN:              ${{ secrets.GITHUB_TOKEN }}
+      TRIOS_REPO:            gHashTag/trios
+      ISSUE:                 "143"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Build tri-railway
+        run: cargo build --release --bin tri-railway --locked
+
+      - name: Audit Acc1 / IGLA
+        id: acc1
+        env:
+          RAILWAY_TOKEN: ${{ env.ACC1_TOKEN }}
+        run: |
+          set +e
+          ./target/release/tri-railway audit run \
+              --project "$ACC1_PROJECT" \
+              --target "$TARGET" \
+              --json \
+              --root . > /tmp/acc1.txt 2>&1
+          echo "exit=$?" >> $GITHUB_OUTPUT
+          cat /tmp/acc1.txt
+          # Last line of stdout from --json is a single JSON object.
+          tail -n 1 /tmp/acc1.txt > /tmp/acc1.json
+          # Surface verdict for the next step.
+          jq -r '.verdict' /tmp/acc1.json >> $GITHUB_OUTPUT 2>/dev/null || true
+
+      - name: Audit Acc2 / IGLA-MIRROR-2
+        id: acc2
+        env:
+          RAILWAY_TOKEN: ${{ env.ACC2_TOKEN }}
+        run: |
+          set +e
+          ./target/release/tri-railway audit run \
+              --project "$ACC2_PROJECT" \
+              --target "$TARGET" \
+              --json \
+              --root . > /tmp/acc2.txt 2>&1
+          echo "exit=$?" >> $GITHUB_OUTPUT
+          cat /tmp/acc2.txt
+          tail -n 1 /tmp/acc2.txt > /tmp/acc2.json
+          jq -r '.verdict' /tmp/acc2.json >> $GITHUB_OUTPUT 2>/dev/null || true
+
+      - name: Build digest comment
+        id: digest
+        run: |
+          ts=$(date -u +%Y-%m-%dT%H:%MZ)
+          a1v=$(jq -r '.verdict      // "?"' /tmp/acc1.json)
+          a1s=$(jq -r '.services     // 0'   /tmp/acc1.json)
+          a1e=$(jq -r '.events|length // 0'  /tmp/acc1.json)
+          a1l=$(jq -r '.ledger_rows  // 0'   /tmp/acc1.json)
+          a2v=$(jq -r '.verdict      // "?"' /tmp/acc2.json)
+          a2s=$(jq -r '.services     // 0'   /tmp/acc2.json)
+          a2e=$(jq -r '.events|length // 0'  /tmp/acc2.json)
+          a2l=$(jq -r '.ledger_rows  // 0'   /tmp/acc2.json)
+          x1=${{ steps.acc1.outputs.exit }}
+          x2=${{ steps.acc2.outputs.exit }}
+
+          # Combined exit. PASS only when both clusters agree.
+          if [[ "$x1" == "1" || "$x2" == "1" ]]; then combined=1
+          elif [[ "$x1" == "0" && "$x2" == "0" ]]; then combined=0
+          else combined=2
+          fi
+          echo "combined=$combined" >> $GITHUB_OUTPUT
+
+          {
+            echo "## 🛰️ Audit Watchdog — $ts (target BPB $TARGET)"
+            echo ""
+            echo "| Cluster | Project | Services | Ledger rows | Drift events | Verdict | Exit |"
+            echo "|---|---|---:|---:|---:|---|---:|"
+            echo "| Acc1 / IGLA           | $ACC1_PROJECT | $a1s | $a1l | $a1e | $a1v | $x1 |"
+            echo "| Acc2 / IGLA-MIRROR-2  | $ACC2_PROJECT | $a2s | $a2l | $a2e | $a2v | $x2 |"
+            echo ""
+            echo "**Combined exit:** $combined  (0 = GATE-2 PASS · 1 = DRIFT · 2 = NOT YET)"
+            echo ""
+            echo "_Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}_"
+            echo ""
+            echo "phi^2 + phi^-2 = 3 · TRINITY · NEVER STOP"
+          } > /tmp/comment.md
+          cat /tmp/comment.md
+
+      - name: Comment on trios#143
+        if: ${{ inputs.skip_comment != 'true' }}
+        run: gh issue comment "$ISSUE" --repo "$TRIOS_REPO" --body-file /tmp/comment.md
+
+      - name: Close #143 on GATE-2 PASS
+        if: ${{ steps.digest.outputs.combined == '0' && inputs.skip_comment != 'true' }}
+        run: |
+          gh issue close "$ISSUE" --repo "$TRIOS_REPO" \
+              --reason completed \
+              --comment "🎯 GATE-2 PASS reached on both clusters at target BPB $TARGET. L-R14 closed. Closing per audit verdict (exit 0). phi^2 + phi^-2 = 3."
+
+      - name: Fail workflow on DRIFT
+        if: ${{ steps.digest.outputs.combined == '1' }}
+        run: |
+          echo "::error::DRIFT detected on at least one cluster (acc1=${{ steps.acc1.outputs.exit }}, acc2=${{ steps.acc2.outputs.exit }})"
+          exit 1


### PR DESCRIPTION
## Summary

Closes [#16](https://github.com/gHashTag/trios-railway/issues/16). Refs [trios#143](https://github.com/gHashTag/trios/issues/143).

Hourly cron that drives the freshly-merged `tri-railway audit run`
([#9](https://github.com/gHashTag/trios-railway/pull/29) / [PR #29](https://github.com/gHashTag/trios-railway/pull/29) merged at 14:58Z) against
**both** Railway clusters and posts a digest to `trios#143`. This is the
deterministic L-R14 closure path: when both clusters report `GATE-2 PASS`
(combined exit 0), the workflow auto-closes `trios#143` with a completion
comment.

Anchor: `phi^2 + phi^-2 = 3`.

## What it does

| Step | Action |
|---|---|
| 1 | `cargo build --release --bin tri-railway --locked` (cached) |
| 2 | `tri-railway audit run --target 1.85 --json` × 2 clusters (parallel via single workflow steps) |
| 3 | jq-reduce both JSON outputs → one markdown table |
| 4 | `gh issue comment 143 --repo gHashTag/trios` |
| 5 | Route by **combined** exit |

### Cluster matrix posted to `trios#143`

```markdown
| Cluster              | Project       | Services | Ledger rows | Drift events | Verdict      | Exit |
|----------------------|---------------|----------|-------------|--------------|--------------|------|
| Acc1 / IGLA          | e4fe33bb-…    |       18 |           N |            E | NOT YET      |    2 |
| Acc2 / IGLA-MIRROR-2 | 39d833c1-…    |        6 |           N |            E | NOT YET      |    2 |
```

### Exit-code routing

| Combined | Meaning | Action |
|---:|---|---|
| **0** | GATE-2 PASS on **both** clusters | `gh issue close 143 --reason completed` + completion comment |
| **1** | DRIFT on at least one cluster | digest comment + workflow fails (red watchdog on GitHub Actions) |
| **2** | NOT YET | digest comment + workflow passes |

## Triggers

- **`schedule`**: `5 * * * *` (5 minutes past every UTC hour)
- **`workflow_dispatch`**: operator can pick a different `target` (e.g. `1.50` for the IGLA goal) and toggle `skip_comment=true` for dry-run

## Secrets used (already set in this repo)

- `RAILWAY_TOKEN_ACC1` (Personal API token, Bearer via `RAILWAY_TOKEN_AUTH=team`)
- `RAILWAY_TOKEN_ACC2` (same)
- `RAILWAY_PROJECT_ACC1_IGLA` = `e4fe33bb-…`
- `RAILWAY_PROJECT_ACC2_TE`   = `39d833c1-…`

## Concurrency

`group: audit-watchdog`, `cancel-in-progress: false` — overlapping triggers
serialize instead of being dropped, so we never lose an audit round.

## R5-honest verification

The same command this workflow runs has already been executed against
prod against both clusters at 15:01Z today:

- **Acc1 / IGLA** → 18 services, 16 D1_ORPHAN warns, NOT YET, exit=2,
  R7 sealed `RAIL=audit @ project=e4fe33bb service=- sha=6d1428a48dcf3c18 ts=2026-04-27T15:01:31Z`
- **Acc2 / IGLA-MIRROR-2** → 6 services, 3 D1_ORPHAN warns, NOT YET, exit=2

See [the live mission update on `trios#143`](https://github.com/gHashTag/trios/issues/143#issuecomment-4328047416).

## Follow-up dependencies

- Drift events will keep showing as `D1_ORPHAN` until [#8](https://github.com/gHashTag/trios-railway/issues/8) (Neon writer)
  starts populating `railway_audit_events`. After #8 lands, the workflow
  will start surfacing real BPB rows from the 6 trainers and verdict will
  flip from NOT YET → GATE-2 PASS organically.
- [#17](https://github.com/gHashTag/trios-railway/issues/17) will expose `audit_run`
  as an MCP tool so this same logic can be called from any agent (not just CI).

φ² + φ⁻² = 3 | TRINITY | NEVER STOP