### PR TITLE
feat(audit): Neon audit_event writer + AuditArtifact JSON (closes #8)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,6 +77,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -162,10 +173,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -194,6 +220,17 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "chrono"
@@ -250,10 +287,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmov"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "core-foundation-sys"
@@ -271,6 +320,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -278,6 +336,24 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
@@ -321,8 +397,20 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid",
+ "crypto-common 0.2.1",
+ "ctutils",
 ]
 
 [[package]]
@@ -357,6 +445,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "fastrand"
@@ -498,7 +592,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
@@ -525,6 +619,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -555,6 +650,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.2",
+]
 
 [[package]]
 name = "http"
@@ -600,6 +704,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -871,6 +984,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -881,6 +1003,15 @@ name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -910,6 +1041,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
+name = "md-5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if",
+ "digest 0.11.2",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -928,7 +1069,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
 ]
 
@@ -951,6 +1092,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "objc2-system-configuration"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396"
+dependencies = [
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -961,6 +1120,29 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
 
 [[package]]
 name = "paste"
@@ -975,10 +1157,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_shared",
+ "serde",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "postgres-protocol"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56201207dac53e2f38e848e31b4b91616a6bb6e0c7205b77718994a7f49e70fc"
+dependencies = [
+ "base64",
+ "byteorder",
+ "bytes",
+ "fallible-iterator",
+ "hmac",
+ "md-5",
+ "memchr",
+ "rand 0.10.1",
+ "sha2 0.11.0",
+ "stringprep",
+]
+
+[[package]]
+name = "postgres-types"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8dc729a129e682e8d24170cd30ae1aa01b336b096cbb56df6d534ffec133d186"
+dependencies = [
+ "bytes",
+ "chrono",
+ "fallible-iterator",
+ "postgres-protocol",
+ "serde_core",
+ "serde_json",
+]
 
 [[package]]
 name = "potential_utf"
@@ -1046,7 +1279,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1100,7 +1333,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1110,7 +1354,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1120,6 +1364,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -1226,7 +1485,7 @@ dependencies = [
  "http-body-util",
  "paste",
  "pin-project-lite",
- "rand",
+ "rand 0.9.4",
  "rmcp-macros",
  "schemars",
  "serde",
@@ -1347,6 +1606,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1436,8 +1701,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -1464,6 +1740,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "siphasher"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "slab"
@@ -1505,6 +1787,17 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
 
 [[package]]
 name = "strsim"
@@ -1661,6 +1954,32 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-postgres"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dd8df5ef180f6364759a6f00f7aadda4fbbac86cdee37480826a6ff9f3574ce"
+dependencies = [
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "fallible-iterator",
+ "futures-channel",
+ "futures-util",
+ "log",
+ "parking_lot",
+ "percent-encoding",
+ "phf",
+ "pin-project-lite",
+ "postgres-protocol",
+ "postgres-types",
+ "rand 0.10.1",
+ "socket2",
+ "tokio",
+ "tokio-util",
+ "whoami",
 ]
 
 [[package]]
@@ -1830,6 +2149,8 @@ dependencies = [
  "chrono",
  "serde",
  "serde_json",
+ "tokio",
+ "tokio-postgres",
  "tracing",
  "trios-railway-core",
  "uuid",
@@ -1845,7 +2166,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
@@ -1898,10 +2219,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-xid"
@@ -1979,6 +2321,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasi"
+version = "0.14.7+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
 name = "wasip2"
 version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1994,6 +2345,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasite"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fe902b4a6b8028a753d5424909b764ccf79b7a209eac9bf97e59cda9f71a42"
+dependencies = [
+ "wasi 0.14.7+wasi-0.2.4",
 ]
 
 [[package]]
@@ -2112,6 +2472,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "whoami"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d"
+dependencies = [
+ "libc",
+ "libredox",
+ "objc2-system-configuration",
+ "wasite",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ thiserror   = "1.0"
 serde       = { version = "1.0", features = ["derive"] }
 serde_json  = "1.0"
 tokio       = { version = "1", features = ["macros", "rt-multi-thread", "fs", "io-util"] }
+tokio-postgres = { version = "0.7", features = ["with-chrono-0_4", "with-serde_json-1"] }
 tracing     = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 axum        = "0.8"

--- a/crates/trios-railway-audit/Cargo.toml
+++ b/crates/trios-railway-audit/Cargo.toml
@@ -12,10 +12,12 @@ rust-version.workspace = true
 workspace = true
 
 [dependencies]
-anyhow     = { workspace = true }
-chrono     = { workspace = true }
-serde      = { workspace = true }
-serde_json = { workspace = true }
-uuid       = { workspace = true }
-tracing    = { workspace = true }
+anyhow          = { workspace = true }
+chrono          = { workspace = true }
+serde           = { workspace = true }
+serde_json      = { workspace = true }
+uuid            = { workspace = true }
+tracing         = { workspace = true }
+tokio           = { workspace = true }
+tokio-postgres  = { workspace = true }
 trios-railway-core = { path = "../trios-railway-core" }

--- a/crates/trios-railway-audit/src/event.rs
+++ b/crates/trios-railway-audit/src/event.rs
@@ -1,0 +1,172 @@
+//! AU-02 — Neon audit_event writer.
+//!
+//! Writes one row to `igla_race_trials` and returns the inserted `row_id`.
+//! The DDL is owned by `migrations.rs` (issue #6, already in main).
+//!
+//! # Usage
+//!
+//! ```no_run
+//! use trios_railway_audit::event::audit_event;
+//!
+//! #[tokio::main]
+//! async fn main() -> anyhow::Result<()> {
+//!     let row_id = audit_event(
+//!         100,       // seed
+//!         1.83,      // bpb
+//!         2000,      // step
+//!         "abc123",  // image sha (first 8 chars is fine)
+//!         &std::env::var("NEON_DATABASE_URL")?,
+//!     ).await?;
+//!     println!("inserted row_id={row_id}");
+//!     Ok(())
+//! }
+//! ```
+//!
+//! # Table schema (already applied via `tri-railway audit migrate-sql`)
+//!
+//! ```sql
+//! CREATE TABLE IF NOT EXISTS igla_race_trials (
+//!     id         BIGSERIAL PRIMARY KEY,
+//!     seed       INTEGER   NOT NULL,
+//!     bpb        DOUBLE PRECISION NOT NULL,
+//!     step       INTEGER   NOT NULL,
+//!     image_sha  TEXT      NOT NULL,
+//!     recorded_at TIMESTAMPTZ NOT NULL DEFAULT now()
+//! );
+//! ```
+
+use anyhow::{Context, Result};
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+
+/// Opaque row identifier returned after a successful insert.
+pub type RowId = i64;
+
+/// JSON artifact emitted to stdout by `tri railway audit run --neon`.
+///
+/// Allows the hourly watchdog to parse the result without re-querying Neon.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuditArtifact {
+    /// UNIX timestamp of the write.
+    pub ts: i64,
+    /// Seed that was audited.
+    pub seed: i32,
+    /// BPB value recorded.
+    pub bpb: f64,
+    /// Training step at the time of the audit.
+    pub step: i32,
+    /// First 8 chars of the Docker image SHA.
+    pub image_sha: String,
+    /// Neon-assigned row id.
+    pub row_id: RowId,
+    /// Target BPB used for gate evaluation.
+    pub target_bpb: f64,
+    /// Whether this row contributes to Gate-2 PASS.
+    pub gate2_contribution: bool,
+}
+
+impl AuditArtifact {
+    /// Build an artifact from writer output.
+    #[must_use]
+    pub fn new(seed: i32, bpb: f64, step: i32, image_sha: &str, row_id: RowId, target_bpb: f64) -> Self {
+        Self {
+            ts: Utc::now().timestamp(),
+            seed,
+            bpb,
+            step,
+            image_sha: image_sha[..image_sha.len().min(8)].to_string(),
+            row_id,
+            target_bpb,
+            gate2_contribution: bpb < target_bpb,
+        }
+    }
+}
+
+/// Insert one audit row into `igla_race_trials` and return the row id.
+///
+/// # Arguments
+///
+/// * `seed`      – integer seed (100, 101, 102, …)
+/// * `bpb`       – bits-per-byte from the trainer log
+/// * `step`      – training step at which BPB was measured
+/// * `image_sha` – Docker image digest / git sha (first 8 chars minimum)
+/// * `neon_url`  – full `postgres://` connection string (`NEON_DATABASE_URL`)
+///
+/// # Errors
+///
+/// Returns `Err` on connection failure, SQL error, or missing env.
+/// Never silently swallows errors (R5).
+pub async fn audit_event(
+    seed: i32,
+    bpb: f64,
+    step: i32,
+    image_sha: &str,
+    neon_url: &str,
+) -> Result<RowId> {
+    let (client, connection) = tokio_postgres::connect(neon_url, tokio_postgres::NoTls)
+        .await
+        .context("connect to Neon")?;
+
+    // Drive the connection in a background task (tokio-postgres pattern).
+    tokio::spawn(async move {
+        if let Err(e) = connection.await {
+            tracing::error!("neon connection error: {e}");
+        }
+    });
+
+    let row = client
+        .query_one(
+            "INSERT INTO igla_race_trials (seed, bpb, step, image_sha) \
+             VALUES ($1, $2, $3, $4) \
+             RETURNING id",
+            &[&seed, &bpb, &step, &image_sha],
+        )
+        .await
+        .context("insert igla_race_trials")?;
+
+    let row_id: RowId = row.get(0);
+    tracing::info!(seed, bpb, step, row_id, "audit_event written to Neon");
+    Ok(row_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn artifact_gate2_contribution_true_below_target() {
+        let a = AuditArtifact::new(100, 1.83, 2000, "abc123def", 42, 1.85);
+        assert!(a.gate2_contribution);
+        assert_eq!(a.image_sha, "abc123de");
+        assert_eq!(a.seed, 100);
+        assert_eq!(a.row_id, 42);
+    }
+
+    #[test]
+    fn artifact_gate2_contribution_false_above_target() {
+        let a = AuditArtifact::new(101, 2.10, 1500, "xyz", 43, 1.85);
+        assert!(!a.gate2_contribution);
+    }
+
+    #[test]
+    fn artifact_image_sha_truncated_to_8() {
+        let a = AuditArtifact::new(102, 1.50, 3000, "0123456789abcdef", 1, 1.85);
+        assert_eq!(a.image_sha.len(), 8);
+        assert_eq!(a.image_sha, "01234567");
+    }
+
+    #[test]
+    fn artifact_image_sha_short_kept_as_is() {
+        let a = AuditArtifact::new(100, 1.50, 100, "abc", 1, 1.85);
+        assert_eq!(a.image_sha, "abc");
+    }
+
+    #[test]
+    fn artifact_serialises_to_json() {
+        let a = AuditArtifact::new(100, 1.83, 2000, "deadbeef", 7, 1.85);
+        let json = serde_json::to_string(&a).expect("serialize");
+        assert!(json.contains("\"gate2_contribution\":true"));
+        assert!(json.contains("\"seed\":100"));
+        assert!(json.contains("\"row_id\":7"));
+    }
+}

--- a/crates/trios-railway-audit/src/event.rs
+++ b/crates/trios-railway-audit/src/event.rs
@@ -1,4 +1,4 @@
-//! AU-02 — Neon audit_event writer.
+//! AU-02 — Neon `audit_event` writer.
 //!
 //! Writes one row to `igla_race_trials` and returns the inserted `row_id`.
 //! The DDL is owned by `migrations.rs` (issue #6, already in main).

--- a/crates/trios-railway-audit/src/event.rs
+++ b/crates/trios-railway-audit/src/event.rs
@@ -68,7 +68,14 @@ pub struct AuditArtifact {
 impl AuditArtifact {
     /// Build an artifact from writer output.
     #[must_use]
-    pub fn new(seed: i32, bpb: f64, step: i32, image_sha: &str, row_id: RowId, target_bpb: f64) -> Self {
+    pub fn new(
+        seed: i32,
+        bpb: f64,
+        step: i32,
+        image_sha: &str,
+        row_id: RowId,
+        target_bpb: f64,
+    ) -> Self {
         Self {
             ts: Utc::now().timestamp(),
             seed,

--- a/crates/trios-railway-audit/src/lib.rs
+++ b/crates/trios-railway-audit/src/lib.rs
@@ -268,7 +268,7 @@ mod tests {
             Some(0.0),
             Some("Failed to load data/tiny_shakespeare.txt"),
         )];
-        let events = detect(&real, &events);
+        let events = detect(&real, &[]);
         assert_eq!(verdict(&real, &events, 1.85), AuditVerdict::Drift);
     }
 }

--- a/crates/trios-railway-audit/src/lib.rs
+++ b/crates/trios-railway-audit/src/lib.rs
@@ -7,10 +7,12 @@
 //!   - `Severity`
 //!   - in-memory `detect()` over typed inputs
 //!
-//! The Neon writer (issue #6/#8) consumes `DriftEvent` rows and inserts
-//! them via `tri railway audit run`. Cron + GitHub Actions integration
+//! AU-02 (issue #8): `event` module adds the Neon writer.
+//! The Neon writer consumes `DriftEvent` rows and inserts
+//! them via `tri railway audit run --neon`. Cron + GitHub Actions integration
 //! lives behind issue #16.
 
+pub mod event;
 pub mod migrations;
 
 use serde::{Deserialize, Serialize};
@@ -266,7 +268,7 @@ mod tests {
             Some(0.0),
             Some("Failed to load data/tiny_shakespeare.txt"),
         )];
-        let events = detect(&real, &[]);
+        let events = detect(&real, &events);
         assert_eq!(verdict(&real, &events, 1.85), AuditVerdict::Drift);
     }
 }


### PR DESCRIPTION
## Problem ([#8](https://github.com/gHashTag/trios-railway/issues/8))

Ledger currently empty — `tri railway audit run` has drift detector and verdict CLI, but **no Neon writer**. Watchdog exits `2 / NOT YET` forever because nothing commits BPB rows to `igla_race_trials`. Gate-2 can never flip to `PASS`.

## Changes

### `Cargo.toml` (workspace)
- ✅ Add `tokio-postgres = { version = "0.7", features = ["with-chrono-0_4", "with-serde_json-1"] }`

### `crates/trios-railway-audit/Cargo.toml`
- ✅ Add `tokio` + `tokio-postgres` deps

### `crates/trios-railway-audit/src/event.rs` **(new)**
- ✅ `audit_event(seed, bpb, step, image_sha, neon_url) -> Result<RowId>` — async fn, inserts one row into `igla_race_trials`, returns `BIGSERIAL` id
- ✅ Background task pattern for tokio-postgres connection driver
- ✅ `AuditArtifact` struct — JSON stdout artifact for watchdog parsing:
  - `ts`, `seed`, `bpb`, `step`, `image_sha` (truncated to 8 chars)
  - `row_id` — the Neon-assigned id for correlation
  - `target_bpb` + `gate2_contribution: bool` — R5 honest flag
- ✅ 5 unit tests (no network needed)

### `crates/trios-railway-audit/src/lib.rs`
- ✅ `pub mod event;` added

## How watchdog wires in (next step)

```rust
let row_id = audit_event(seed, bpb, step, &sha, &neon_url).await?;
let artifact = AuditArtifact::new(seed, bpb, step, &sha, row_id, target_bpb);
println!("{}", serde_json::to_string(&artifact)?);
```

The hourly watchdog parses the JSON artifact and builds the leaderboard table for `#143`. Combined exit 0 → `#143` closes automatically.

## Gate-2 Path After Merge

```
Neon writer active → igla_race_trials fills with BPB rows every hour
≥3 services with bpb < 1.85 → verdict Gate2Pass → exit 0
Watchdog exits 0 → #143 closes → L-R14 CLOSED
```

## Acceptance Criteria

- [ ] `cargo test -p trios-railway-audit` PASS (5 new tests)
- [ ] `cargo clippy -- -D warnings` = 0
- [ ] `cargo build --workspace` succeeds (tokio-postgres compiles)
- [ ] Integration test: `audit_event(100, 1.83, 2000, "abc123", $NEON_DATABASE_URL)` inserts row, returns `row_id > 0`

---

**φ² + φ⁻² = 3 | AU-02 | Closes #8**