### PR TITLE
fix(watchdog): robust JSON extraction from audit run --json (refs #16)

### DIFF
--- a/.github/workflows/audit-watchdog.yml
+++ b/.github/workflows/audit-watchdog.yml
@@ -68,17 +68,29 @@ jobs:
           RAILWAY_TOKEN: ${{ env.ACC1_TOKEN }}
         run: |
           set +e
+          # tri-railway prints its text summary AND a single-line JSON
+          # blob (with --json) to stdout, plus tracing-subscriber lines
+          # on stderr. Capture stdout to acc1.txt and stderr to acc1.log;
+          # then extract the JSON line by matching the last line that
+          # starts with '{' (the --json output is guaranteed to be on a
+          # single line ending with '}').
           ./target/release/tri-railway audit run \
               --project "$ACC1_PROJECT" \
               --target "$TARGET" \
               --json \
-              --root . > /tmp/acc1.txt 2>&1
-          echo "exit=$?" >> $GITHUB_OUTPUT
+              --root . > /tmp/acc1.txt 2> /tmp/acc1.log
+          echo "exit=$?" >> "$GITHUB_OUTPUT"
+          echo '----- stdout -----'
           cat /tmp/acc1.txt
-          # Last line of stdout from --json is a single JSON object.
-          tail -n 1 /tmp/acc1.txt > /tmp/acc1.json
-          # Surface verdict for the next step.
-          jq -r '.verdict' /tmp/acc1.json >> $GITHUB_OUTPUT 2>/dev/null || true
+          echo '----- stderr (tracing) -----'
+          cat /tmp/acc1.log || true
+          # Pick the last line whose first non-space char is '{' — robust
+          # against text summary above and tracing being merged in.
+          grep -E '^\s*\{' /tmp/acc1.txt | tail -n 1 > /tmp/acc1.json
+          if [[ ! -s /tmp/acc1.json ]]; then
+            echo '{"error":"no JSON line in audit run output","verdict":"DRIFT","exit_code":1,"services":0,"events":[],"ledger_rows":0,"target":'"$TARGET"',"project":"'"$ACC1_PROJECT"'","project_name":"unknown"}' > /tmp/acc1.json
+          fi
+          jq -r '.verdict // "?"' /tmp/acc1.json >> "$GITHUB_OUTPUT" 2>/dev/null || true
 
       - name: Audit Acc2 / IGLA-MIRROR-2
         id: acc2
@@ -90,11 +102,17 @@ jobs:
               --project "$ACC2_PROJECT" \
               --target "$TARGET" \
               --json \
-              --root . > /tmp/acc2.txt 2>&1
-          echo "exit=$?" >> $GITHUB_OUTPUT
+              --root . > /tmp/acc2.txt 2> /tmp/acc2.log
+          echo "exit=$?" >> "$GITHUB_OUTPUT"
+          echo '----- stdout -----'
           cat /tmp/acc2.txt
-          tail -n 1 /tmp/acc2.txt > /tmp/acc2.json
-          jq -r '.verdict' /tmp/acc2.json >> $GITHUB_OUTPUT 2>/dev/null || true
+          echo '----- stderr (tracing) -----'
+          cat /tmp/acc2.log || true
+          grep -E '^\s*\{' /tmp/acc2.txt | tail -n 1 > /tmp/acc2.json
+          if [[ ! -s /tmp/acc2.json ]]; then
+            echo '{"error":"no JSON line in audit run output","verdict":"DRIFT","exit_code":1,"services":0,"events":[],"ledger_rows":0,"target":'"$TARGET"',"project":"'"$ACC2_PROJECT"'","project_name":"unknown"}' > /tmp/acc2.json
+          fi
+          jq -r '.verdict // "?"' /tmp/acc2.json >> "$GITHUB_OUTPUT" 2>/dev/null || true
 
       - name: Build digest comment
         id: digest


### PR DESCRIPTION
## Summary

Refs [#16](https://github.com/gHashTag/trios-railway/issues/16) /
[trios#143](https://github.com/gHashTag/trios/issues/143).

The first scheduled hourly run of `audit-watchdog.yml` failed with:

```
jq: parse error: Invalid numeric literal at line 1, column 2
```

[`run 25002865475`](https://github.com/gHashTag/trios-railway/actions/runs/25002865475/job/73213117928).

Anchor: `phi^2 + phi^-2 = 3`.

## Root cause

`tail -n 1` was applied to the merged `2>&1` stream of `tri-railway audit run --json`.
The binary already writes tracing-subscriber output to **stderr**
([main.rs `with_writer(io::stderr)`](https://github.com/gHashTag/trios-railway/blob/main/bin/tri-railway/src/main.rs#L196)),
but the workflow folded both back into one file. The last line of that merged
stream was the `INFO audit triplet sealed experience=...` line that prints
**after** the `--json` blob — `jq` understandably refused to parse it.

## Fix

```diff
-          ./target/release/tri-railway audit run ... > /tmp/acc1.txt 2>&1
-          tail -n 1 /tmp/acc1.txt > /tmp/acc1.json
+          ./target/release/tri-railway audit run ... > /tmp/acc1.txt 2> /tmp/acc1.log
+          grep -E "^\s*\{" /tmp/acc1.txt | tail -n 1 > /tmp/acc1.json
+          if [[ ! -s /tmp/acc1.json ]]; then
+            echo "{\"verdict\":\"DRIFT\",\"exit_code\":1,...}" > /tmp/acc1.json
+          fi
```

Three improvements:
1. **Split stdout / stderr** — the binary always writes tracing to stderr; reflect that in the workflow.
2. **Anchor on `^\s*\{`** — the `--json` blob is a single line that starts with `{`; this is robust against future additions to the human-readable summary above it.
3. **Synthesize a DRIFT fallback** when grep finds nothing (network error, panic) — the digest step never crashes, the watchdog goes red on combined `exit=1` instead of failing in the middle.
4. Echo both stdout and stderr to the workflow log for triage.

## Local verification (R5-honest)

Reproduced the production stdout/stderr split using the same binary
that the workflow builds, against the live IGLA project with the
Acc1 Personal API token:

```
$ ./target/release/tri-railway audit run --project e4fe33bb-... --target 1.85 \
      --json --root /tmp/audit-prod > /tmp/test_stdout.txt 2> /tmp/test_stderr.txt

$ tail -n 3 /tmp/test_stdout.txt
  [Warn] D1OrphanService {"msg":"no ledger row","service":"igla-trainer-seed-43"}
verdict: NOT YET  (exit 2)
{"events":[{"code":"D1_ORPHAN_SERVICE",...}],"exit_code":2,"verdict":"NOT YET",...}

$ cat /tmp/test_stderr.txt
INFO tri_railway: audit triplet sealed experience=/tmp/audit-prod/.trinity/experience/trios_railway_20260427.trinity

$ grep -E "^\s*\{" /tmp/test_stdout.txt | tail -n 1 | jq -r ".verdict, .services, .exit_code, .ledger_rows"
NOT YET
18
2
0
```

The current cron (`5 * * * *` UTC) will fire at 16:05Z; the next run after merge
should turn green.

## Why no Rust changes

The binary is already correct (tracing-on-stderr is the right default for a
CLI; JSON-on-stdout is the right default for `--json`). The bug was purely in
the workflow harness assuming a merged stream. Keeping the fix in the workflow
file means no rebuild and the binary stays usable from any other harness
(MCP tool [#17](https://github.com/gHashTag/trios-railway/issues/17), local
shell, cron).

φ² + φ⁻² = 3 | TRINITY | NEVER STOP