### PR TITLE
fix(watchdog): encode verdict in GITHUB_OUTPUT with key=value (refs #16)

### DIFF
--- a/.github/workflows/audit-watchdog.yml
+++ b/.github/workflows/audit-watchdog.yml
@@ -90,7 +90,10 @@ jobs:
           if [[ ! -s /tmp/acc1.json ]]; then
             echo '{"error":"no JSON line in audit run output","verdict":"DRIFT","exit_code":1,"services":0,"events":[],"ledger_rows":0,"target":'"$TARGET"',"project":"'"$ACC1_PROJECT"'","project_name":"unknown"}' > /tmp/acc1.json
           fi
-          jq -r '.verdict // "?"' /tmp/acc1.json >> "$GITHUB_OUTPUT" 2>/dev/null || true
+          V=$(jq -r '.verdict // "?"' /tmp/acc1.json 2>/dev/null || echo '?')
+          # GitHub Actions outputs need key=value (no spaces in value
+          # without explicit format), so encode the verdict.
+          printf 'verdict=%s\n' "${V// /_}" >> "$GITHUB_OUTPUT"
 
       - name: Audit Acc2 / IGLA-MIRROR-2
         id: acc2
@@ -112,7 +115,8 @@ jobs:
           if [[ ! -s /tmp/acc2.json ]]; then
             echo '{"error":"no JSON line in audit run output","verdict":"DRIFT","exit_code":1,"services":0,"events":[],"ledger_rows":0,"target":'"$TARGET"',"project":"'"$ACC2_PROJECT"'","project_name":"unknown"}' > /tmp/acc2.json
           fi
-          jq -r '.verdict // "?"' /tmp/acc2.json >> "$GITHUB_OUTPUT" 2>/dev/null || true
+          V=$(jq -r '.verdict // "?"' /tmp/acc2.json 2>/dev/null || echo '?')
+          printf 'verdict=%s\n' "${V// /_}" >> "$GITHUB_OUTPUT"
 
       - name: Build digest comment
         id: digest


### PR DESCRIPTION
Follow-up to [#32](https://github.com/gHashTag/trios-railway/pull/32). The
JSON parse is now correct, but writing the raw verdict (`NOT YET`)
into `$GITHUB_OUTPUT` without a `key=` prefix made the runner reject
the file command:

```
##[error]Unable to process file command output successfully.
##[error]Invalid format NOT YET
```

[`run 25003791643`](https://github.com/gHashTag/trios-railway/actions/runs/25003791643/job/73215933167).

Two-line fix: `printf "verdict=%s\n" "${V// /_}"` so the value is a
single underscore-delimited token.

Verified the surrounding logic:
- the digest step reads from the JSON file (`jq -r .verdict /tmp/acc1.json`),
  not from `steps.acc1.outputs.verdict`, so the encoding change has no
  downstream effect on the comment posted to `trios#143`.
- the `outputs.exit` field already used the `key=value` form correctly.

After merge, manual `workflow_dispatch` should produce a green digest
comment and exit cleanly.

Refs #16.