### PR TITLE
fix(watchdog): cross-repo PAT support for trios#143 (refs #16)

### DIFF
--- a/.github/workflows/audit-watchdog.yml
+++ b/.github/workflows/audit-watchdog.yml
@@ -42,7 +42,12 @@ jobs:
       ACC2_PROJECT:          ${{ secrets.RAILWAY_PROJECT_ACC2_TE }}
       RAILWAY_TOKEN_AUTH:    team
       RUST_LOG:              info
-      GH_TOKEN:              ${{ secrets.GITHUB_TOKEN }}
+      # Cross-repo writes: prefer the user-provided fine-grained PAT
+      # (TRIOS_REPO_PAT, scoped issues:write on gHashTag/trios). Fall back
+      # to the workflow's GITHUB_TOKEN, which can only post to the current
+      # repo. The comment / close steps are guarded with `if:` so missing
+      # PAT yields a green run with a clear log line, not a failure.
+      GH_TOKEN:              ${{ secrets.TRIOS_REPO_PAT || secrets.GITHUB_TOKEN }}
       TRIOS_REPO:            gHashTag/trios
       ISSUE:                 "143"
 
@@ -157,11 +162,21 @@ jobs:
           cat /tmp/comment.md
 
       - name: Comment on trios#143
-        if: ${{ inputs.skip_comment != 'true' }}
+        if: ${{ inputs.skip_comment != 'true' && env.HAS_PAT == 'true' }}
+        env:
+          HAS_PAT: ${{ secrets.TRIOS_REPO_PAT != '' }}
         run: gh issue comment "$ISSUE" --repo "$TRIOS_REPO" --body-file /tmp/comment.md
 
+      - name: Skip comment (no cross-repo PAT)
+        if: ${{ inputs.skip_comment != 'true' && secrets.TRIOS_REPO_PAT == '' }}
+        run: |
+          echo '::warning::TRIOS_REPO_PAT not set; cannot post to gHashTag/trios#143.'
+          echo '::warning::Add a fine-grained PAT with issues:write on gHashTag/trios as TRIOS_REPO_PAT.'
+          echo '----- comment that would have been posted -----'
+          cat /tmp/comment.md
+
       - name: Close #143 on GATE-2 PASS
-        if: ${{ steps.digest.outputs.combined == '0' && inputs.skip_comment != 'true' }}
+        if: ${{ steps.digest.outputs.combined == '0' && inputs.skip_comment != 'true' && secrets.TRIOS_REPO_PAT != '' }}
         run: |
           gh issue close "$ISSUE" --repo "$TRIOS_REPO" \
               --reason completed \

--- a/docs/CROSS_REPO_PAT.md
+++ b/docs/CROSS_REPO_PAT.md
@@ -1,0 +1,69 @@
+# Cross-repo PAT for the audit watchdog
+
+Anchor: `phi^2 + phi^-2 = 3`. Refs [#16].
+
+The hourly `audit-watchdog.yml` workflow lives in `gHashTag/trios-railway`
+but posts its digest to `gHashTag/trios#143`. The default `GITHUB_TOKEN`
+is scoped to the workflow's own repo — cross-repo writes fail with:
+
+```
+GraphQL: Resource not accessible by integration (addComment)
+```
+
+To enable comment + auto-close, add a **fine-grained Personal Access Token**.
+
+## One-time setup (5 min)
+
+1. Open <https://github.com/settings/personal-access-tokens/new>.
+2. Settings:
+   - **Token name:** `trios-railway audit watchdog`
+   - **Resource owner:** `gHashTag` (the user/org that owns `trios`)
+   - **Expiration:** 90 days (recommended) or longer
+   - **Repository access:** `Only select repositories` → pick `gHashTag/trios`
+   - **Repository permissions** (only these — least privilege):
+     - `Issues` → `Read and write`
+     - everything else → leave at `No access`
+3. Click **Generate token**, copy the value (starts with `github_pat_…`).
+4. Save it to `gHashTag/trios-railway` Actions secrets:
+
+```bash
+gh secret set TRIOS_REPO_PAT --repo gHashTag/trios-railway
+# (paste token, hit enter)
+```
+
+5. Verify:
+
+```bash
+gh secret list --repo gHashTag/trios-railway | grep TRIOS_REPO_PAT
+gh workflow run audit-watchdog.yml --repo gHashTag/trios-railway --ref main \
+    -f target=1.85 -f skip_comment=false
+```
+
+The next watchdog run posts a digest to `trios#143` and (on combined exit 0)
+auto-closes it.
+
+## How the workflow uses it
+
+```yaml
+env:
+  GH_TOKEN: ${{ secrets.TRIOS_REPO_PAT || secrets.GITHUB_TOKEN }}
+```
+
+If `TRIOS_REPO_PAT` is missing, the comment and close steps short-circuit
+on `if:` guards and the workflow logs a `::warning::` instead of failing.
+This means the same workflow file works in three modes:
+
+| `TRIOS_REPO_PAT` | `inputs.skip_comment` | Behaviour |
+|---|---|---|
+| set    | false | Posts digest, closes on PASS |
+| unset  | false | Logs warning, prints draft comment, exits green |
+| any    | true  | Dry run — runs audit, no side effects on `trios#143` |
+
+## Rotation
+
+Fine-grained PATs expire. Set a calendar reminder one week before
+expiration; rotate by repeating step 1 with a fresh token, then
+`gh secret set TRIOS_REPO_PAT --repo gHashTag/trios-railway` again.
+
+If the watchdog suddenly starts logging the warning above, the PAT
+likely expired.


### PR DESCRIPTION
## Summary

Refs [#16](https://github.com/gHashTag/trios-railway/issues/16) /
[trios#143](https://github.com/gHashTag/trios/issues/143).

The hourly watchdog was failing on the comment step:

```
GraphQL: Resource not accessible by integration (addComment)
```

[`run 25004099587`](https://github.com/gHashTag/trios-railway/actions/runs/25004099587/job/73217205769).

The default `GITHUB_TOKEN` is scoped to the workflow `s own repo. The
watchdog lives in `trios-railway` but writes to `trios` — fundamentally
needs a cross-repo token.

## Fix

```yaml
env:
  GH_TOKEN: ${{ secrets.TRIOS_REPO_PAT || secrets.GITHUB_TOKEN }}

# ...

- name: Comment on trios#143
  if: inputs.skip_comment != "true" && secrets.TRIOS_REPO_PAT != ""
  run: gh issue comment ...

- name: Skip comment (no cross-repo PAT)
  if: inputs.skip_comment != "true" && secrets.TRIOS_REPO_PAT == ""
  run: |
    echo "::warning::TRIOS_REPO_PAT not set; cannot post to gHashTag/trios#143."
    cat /tmp/comment.md   # log the draft anyway, for operator audit
```

Three modes:

| `TRIOS_REPO_PAT` | `skip_comment` | Behaviour |
|---|---|---|
| set    | false | Posts digest, auto-closes on PASS |
| unset  | false | Logs `::warning::` + draft, run stays green |
| any    | true  | Dry run, no side effects |

Adds [`docs/CROSS_REPO_PAT.md`](https://github.com/gHashTag/trios-railway/blob/fix/watchdog-cross-repo-pat/docs/CROSS_REPO_PAT.md)
with one-time setup using a least-privilege fine-grained PAT
(repo-scoped to `gHashTag/trios`, only `Issues: Read and write`,
nothing else).

## Operator action after merge

1. Open <https://github.com/settings/personal-access-tokens/new>
2. Resource owner: `gHashTag` · Repos: `gHashTag/trios` · Permissions: Issues = Read & write
3. `gh secret set TRIOS_REPO_PAT --repo gHashTag/trios-railway` (paste token)
4. The next hourly run (or a manual `workflow_dispatch`) starts posting to `trios#143`.

If you skip step 3, the watchdog stays green but does not comment.
That is intentional — Gate-2 progress should never be blocked by a
missing operator-only credential.

## R5-honest verification

Without `TRIOS_REPO_PAT`, the previous build steps were already passing.
`run 25004006785` (with `skip_comment=true`) confirmed the audit-and-build
pipeline runs end-to-end. The only failure was the cross-repo step,
which this PR removes from the critical path.

φ² + φ⁻² = 3 | TRINITY | NEVER STOP