### PR TITLE
fix(workflows): YAML scanner — collapse multi-line commit messages (refs #16)

### DIFF
--- a/.github/workflows/deploy-from-template.yml
+++ b/.github/workflows/deploy-from-template.yml
@@ -155,7 +155,5 @@ jobs:
           git config user.name  "fleet-snapshot[bot]"
           git add disaster-recovery/last-restore.json
           git diff --staged --quiet && exit 0 || true
-          git commit -m "chore(dr): record last restore (alias=${ALIAS}, project=${PROJECT_NAME})
-
-[skip ci] phi^2 + phi^-2 = 3"
+          git commit -m "chore(dr): record last restore (alias=${ALIAS}, project=${PROJECT_NAME}) -- [skip ci] phi^2 + phi^-2 = 3"
           git push

--- a/.github/workflows/fleet-snapshot.yml
+++ b/.github/workflows/fleet-snapshot.yml
@@ -82,9 +82,5 @@ jobs:
 
           ts=$(date -u +%Y-%m-%dT%H:%MZ)
           totals=$(python3 -c 'import json; d=json.load(open("disaster-recovery/fleet-snapshot.json")); print(d["totals"])')
-          git commit -m "chore(dr): hourly fleet snapshot @ $ts
-
-Totals: $totals
-
-[skip ci] phi^2 + phi^-2 = 3"
+          git commit -m "chore(dr): hourly fleet snapshot @ $ts -- Totals: $totals -- [skip ci] phi^2 + phi^-2 = 3"
           git push


### PR DESCRIPTION
After PR #36 merged, fleet-snapshot.yml and deploy-from-template.yml failed every trigger with startup_failure. YAML scanner couldn't parse multi-line commit -m strings inside run: | blocks. Trivial fix: single-line commit with -- separators. Verified yaml.safe_load passes on both. Refs #16.