### PR TITLE
docs(dr): add Path D — MCP chat recovery (refs #17, #143)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ repo. **Three trigger paths**, all documented in
 1. **Web button (above)** — published from [`railway-template.json`](railway-template.json). Provisions all 6 control-plane services (1 MCP + 3 champion seeds + dwagent + Neon backup-to-R2 sidecar).
 2. **GitHub Actions** — `Actions → DR Deploy from template → account_alias=accN, confirm=PHI`. Workflow: [`deploy-from-template.yml`](.github/workflows/deploy-from-template.yml).
 3. **CLI** — `tri-railway service deploy …` for each service in [`disaster-recovery/fleet-snapshot.json`](disaster-recovery/fleet-snapshot.json) (refreshed hourly by [`fleet-snapshot.yml`](.github/workflows/fleet-snapshot.yml)).
+4. **MCP chat** — say “восстанови флот на acc3, подтверждаю PHI” to any client connected to the `trios-railway-mcp` server. Tools: `railway_dr_snapshot`, `railway_dr_restore` (issue [#17](https://github.com/gHashTag/trios-railway/issues/17)).
 
 Fleet shape, audit ledger, and champion BPB rows survive any single-account ban
 — see the survives-table in [`docs/DISASTER_RECOVERY.md`](docs/DISASTER_RECOVERY.md).

--- a/docs/DISASTER_RECOVERY.md
+++ b/docs/DISASTER_RECOVERY.md
@@ -6,7 +6,7 @@ This runbook lets you bring the IGLA training fleet back online **in
 under 15 minutes** after a Railway-account ban, payment lapse, or
 catastrophic project deletion.
 
-## TL;DR — three commands
+## TL;DR — three commands (or one chat sentence)
 
 ```bash
 # 1. Provision new Railway account, generate a fresh Personal API token.
@@ -17,6 +17,15 @@ gh secret set RAILWAY_TOKEN_ACC3 --repo gHashTag/trios-railway     # paste token
 # 3. Migrate the audit ledger schema (idempotent).
 ./target/release/tri-railway audit migrate-sql | psql "$NEON_DATABASE_URL"
 ```
+
+Or if `trios-railway-mcp` is reachable from your chat:
+
+```
+“восстанови флот на acc3, подтверждаю PHI”
+```
+
+The agent calls `railway_dr_restore` (path D below) and reports back
+when all 6 services are live.
 
 You are back online.
 
@@ -37,8 +46,9 @@ You are back online.
 
 ## Trigger paths
 
-You have **three** ways to recover. Use whichever is fastest given the
-state of your access.
+You have **four** ways to recover. Use whichever is fastest given the
+state of your access (chat → web → CI → shell, in increasing operator
+friction).
 
 ### A. Railway template button (web UI · ~5 min)
 
@@ -83,6 +93,62 @@ gh workflow run deploy-from-template.yml --repo gHashTag/trios-railway --ref mai
 The workflow reads `railway-template.json`, calls Railway GraphQL to
 create one project + N services, and writes the new IDs back to
 `disaster-recovery/last-restore.json`.
+
+### D. MCP chat (one sentence to any agent, ~5 min including build)
+
+The `trios-railway-mcp` server (deployed at `trios-mcp-public`) exposes
+two disaster-recovery tools that drive paths A–C above without you
+having to leave the chat or open the GitHub UI:
+
+| MCP tool                       | Effect                                                                                                                                |
+|--------------------------------|---------------------------------------------------------------------------------------------------------------------------------------|
+| `railway_dr_snapshot`          | Triggers `fleet-snapshot.yml`, polls until completion, returns the diff of `disaster-recovery/fleet-snapshot.json` between two SHAs.  |
+| `railway_dr_restore`           | Triggers `deploy-from-template.yml` with the chosen `target_account` and `confirm: "PHI"`. Streams workflow logs back through MCP.    |
+
+In natural-language form (any MCP-aware client, e.g. the
+`trios-perplexity` endpoint):
+
+```
+operator: "сделай snapshot флота"
+agent:    → calls railway_dr_snapshot
+          ← returns { services: 29, drift: [...], run_id, commit_sha, html_url }
+
+operator: "восстанови флот на acc3, подтверждаю PHI"
+agent:    → calls railway_dr_restore { target_account: "acc3", confirm: "PHI" }
+          ← returns { deployed_services: […], template_url, run_id, html_url }
+```
+
+#### Safety invariants enforced server-side
+
+1. **`confirm` must equal exactly `"PHI"`** — any other string returns
+   `ToolError::SafetyGate` immediately, no fallback.
+2. **`target_account: "acc1"` is rejected.** DR may target `acc2` or
+   `acc3` only — prevents accidentally redeploying over the live IGLA
+   project. The error message tells you to use the dedicated
+   `railway_service_*` tools if a single-service redeploy on `acc1` is
+   what you actually wanted.
+3. **`TRIOS_REPO_PAT` must be set** in the MCP server's environment.
+   When missing, both tools fail fast with a one-line error pointing at
+   <https://github.com/settings/personal-access-tokens> and the
+   required scope (`actions:write` on `gHashTag/trios-railway`).
+4. **600-second hard timeout** on workflow polling. If a cold cargo
+   build pushes past 10 minutes, the tool returns `ToolError::Timeout`
+   with the live `run_id` so you can keep watching it on the GitHub
+   Actions UI without re-running.
+5. **Every successful tool call seals an R7 triplet** to
+   `.trinity/experience/<YYYYMMDD>.trinity` via the existing experience
+   writer, identical to the `railway_service_deploy` audit trail.
+
+#### Why path D is path D, not path A
+
+Chat is the lowest-friction entry point but also the easiest place to
+fat-finger a destructive command. The safety invariants above
+(especially `confirm == "PHI"` and the `acc1` block) make path D safe
+enough for production; the explicit ordering A→B→C→D in this runbook
+reflects "how much agency you give to the agent", not "speed". For an
+unattended rebuild after a 3 AM ban, you would script path B or C; for
+a quick recovery while you are already chatting with the agent, path D
+is identical in outcome and faster in wall-clock time.
 
 ## Required secrets for full recovery
 


### PR DESCRIPTION
Pre-lands the doc side of [#17](https://github.com/gHashTag/trios-railway/issues/17). This is `c5` from the agreed commit plan, split out so the docs can merge ahead of the Rust code without blocking either.

Anchor: `phi^2 + phi^-2 = 3`.

## What this PR adds

- **`docs/DISASTER_RECOVERY.md`**:
  - "Trigger paths" intro flips three → four (`chat → web → CI → shell`, increasing operator friction).
  - New section **"D. MCP chat"** with:
    - tool table for `railway_dr_snapshot` and `railway_dr_restore`,
    - natural-language usage example (RU/EN-mixed, like real chat),
    - five server-side safety invariants (`confirm == "PHI"`, `acc1` forbidden, `TRIOS_REPO_PAT` required, 600s timeout, R7 triplet seal),
    - rationale "Why path D is path D, not path A" — ordering reflects agency, not speed.
  - TL;DR adds a one-sentence chat alternative.
- **`README.md`**: DR list flips three → four with the MCP-chat option, links to issue #17.

## Why merge ahead of the Rust code

The contract for both tools (names, inputs, safety invariants, error shapes) is fully frozen here. That lets `c1..c4` land as a separate Rust-only PR without re-touching the docs, and keeps each PR small.

## Coupling guarantee

Tool names (`railway_dr_snapshot`, `railway_dr_restore`), accepted `target_account` values (`acc2`, `acc3`), and the magic-string gate (`confirm == "PHI"`) are now spec-bound by this doc. The Rust implementation in #17 must match.

Refs [#17](https://github.com/gHashTag/trios-railway/issues/17) · refs [trios#143](https://github.com/gHashTag/trios/issues/143).