### PR TITLE
feat(dr): restore-fleet.json schema + validation CI (closes #26)

### DIFF
--- a/.github/workflows/manifest-validate.yml
+++ b/.github/workflows/manifest-validate.yml
@@ -1,0 +1,77 @@
+name: Validate restore-fleet manifest schema
+
+# Closes the schema half of #26 by guaranteeing that
+#   - restore-fleet.json always validates against schemas/restore-fleet.schema.json
+#   - the schema itself stays JSON-Schema-Draft-2020-12-conformant
+#   - all positive/negative fixtures in schemas/fixtures/ behave as labelled
+#
+# Anchor: phi^2 + phi^-2 = 3.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "restore-fleet.json"
+      - "schemas/restore-fleet.schema.json"
+      - "schemas/fixtures/**"
+      - ".github/workflows/manifest-validate.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "restore-fleet.json"
+      - "schemas/restore-fleet.schema.json"
+      - "schemas/fixtures/**"
+      - ".github/workflows/manifest-validate.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: python -m pip install --quiet 'jsonschema>=4.21'
+      - name: Validate manifest + fixtures
+        run: |
+          python - <<'PY'
+          import json, pathlib, sys
+          from jsonschema import Draft202012Validator
+
+          schema = json.load(open("schemas/restore-fleet.schema.json"))
+          # 1. Self-check: the schema is itself valid Draft 2020-12.
+          Draft202012Validator.check_schema(schema)
+          v = Draft202012Validator(schema)
+
+          # 2. Live manifest must validate.
+          live = json.load(open("restore-fleet.json"))
+          errs = list(v.iter_errors(live))
+          if errs:
+              print("::error file=restore-fleet.json::live manifest fails schema:")
+              for e in errs:
+                  print(f"  {'.'.join(map(str, e.path)) or '<root>'}: {e.message}")
+              sys.exit(1)
+          print(f"OK live: {len(live['services'])} services, version={live['version']}")
+
+          # 3. Fixtures: filename prefix is the source of truth.
+          fix_dir = pathlib.Path("schemas/fixtures")
+          if fix_dir.is_dir():
+              for f in sorted(fix_dir.iterdir()):
+                  if f.suffix != ".json":
+                      continue
+                  data = json.load(f.open())
+                  errs = list(v.iter_errors(data))
+                  passed = (len(errs) == 0)
+                  expected_pass = f.name.startswith("valid_")
+                  if passed != expected_pass:
+                      label = "passed" if passed else f"failed ({errs[0].message})"
+                      print(f"::error file={f}::expected {'pass' if expected_pass else 'fail'}, got {label}")
+                      sys.exit(1)
+                  print(f"  ok: {f.name} ({'pass' if passed else 'fail-as-expected'})")
+          print("all fixtures behave as labelled")
+          PY

--- a/restore-fleet.json
+++ b/restore-fleet.json
@@ -1,57 +1,102 @@
 {
   "$schema": "./schemas/restore-fleet.schema.json",
+
+  "version": 1,
   "anchor": "phi^2 + phi^-2 = 3",
-  "version": "1.0.0",
+
   "project": {
     "name": "IGLA",
-    "description": "IGLA RACE — anchor phi^2+phi^-2=3 — restored after DR event",
+    "description": "IGLA RACE training fleet — restored after a Railway-account ban or project loss. Anchor: phi^2 + phi^-2 = 3.",
     "default_environment": "production"
   },
-  "image": {
-    "registry": "ghcr.io",
-    "repository": "ghashtag/trios-trainer-igla",
-    "default_tag": "latest",
-    "pin_policy": "by-sha-from-ledger"
-  },
+
+  "image": "ghcr.io/ghashtag/trios-trainer-igla:latest",
+
   "shared_vars": [
-    { "key": "RUST_LOG",         "value": "info" },
-    { "key": "TRIOS_HIDDEN",     "value": "384" },
-    { "key": "TRIOS_LR",         "value": "0.003" },
-    { "key": "TRIOS_OPTIMIZER",  "value": "adamw" },
-    { "key": "TRIOS_STEPS",      "value": "81000" },
-    { "key": "TRIOS_ATTN_LAYERS","value": "2" },
+    { "key": "RUST_LOG",                "value": "info" },
+    { "key": "TRIOS_HIDDEN",            "value": "384" },
+    { "key": "TRIOS_LR",                "value": "0.003" },
+    { "key": "TRIOS_OPTIMIZER",         "value": "adamw" },
+    { "key": "TRIOS_STEPS",             "value": "60000" },
+    { "key": "TRIOS_ATTN_LAYERS",       "value": "2" },
     { "key": "L_R8_SYNTHETIC_FALLBACK", "value": "FORBID" },
-    { "key": "NEON_DATABASE_URL","value": "${secret:NEON_DATABASE_URL}" }
+    { "key": "NEON_DATABASE_URL",       "value": "${secret:NEON_DATABASE_URL}" }
   ],
+
   "services": [
-    { "name": "trios-train-seed-42",   "kind": "trainer", "vars": [{ "key": "TRIOS_SEED", "value": "42"  }] },
-    { "name": "trios-train-seed-43",   "kind": "trainer", "vars": [{ "key": "TRIOS_SEED", "value": "43"  }] },
-    { "name": "trios-train-seed-44",   "kind": "trainer", "vars": [{ "key": "TRIOS_SEED", "value": "44"  }] },
-    { "name": "trios-train-seed-45",   "kind": "trainer", "vars": [{ "key": "TRIOS_SEED", "value": "45"  }] },
-    { "name": "trios-train-seed-46",   "kind": "trainer", "vars": [{ "key": "TRIOS_SEED", "value": "46"  }] },
-    { "name": "trios-train-seed-47",   "kind": "trainer", "vars": [{ "key": "TRIOS_SEED", "value": "47"  }] },
-    { "name": "trios-train-seed-48",   "kind": "trainer", "vars": [{ "key": "TRIOS_SEED", "value": "48"  }] },
-    { "name": "trios-train-seed-100",  "kind": "trainer", "vars": [{ "key": "TRIOS_SEED", "value": "100" }] },
-    { "name": "trios-train-seed-101",  "kind": "trainer", "vars": [{ "key": "TRIOS_SEED", "value": "101" }] },
-    { "name": "trios-train-seed-102",  "kind": "trainer", "vars": [{ "key": "TRIOS_SEED", "value": "102" }] },
-    { "name": "igla-trainer-seed-43",  "kind": "trainer", "vars": [{ "key": "TRIOS_SEED", "value": "43"  }] },
-    { "name": "igla-trainer-seed-100", "kind": "trainer", "vars": [{ "key": "TRIOS_SEED", "value": "100" }] },
-    { "name": "igla-trainer-seed-101", "kind": "trainer", "vars": [{ "key": "TRIOS_SEED", "value": "101" }] },
-    { "name": "igla-trainer-seed-102", "kind": "trainer", "vars": [{ "key": "TRIOS_SEED", "value": "102" }] },
     {
       "name": "trios-mcp-public",
       "kind": "mcp",
-      "image_override": { "registry": "ghcr.io", "repository": "ghashtag/trios-railway-mcp", "tag": "latest" },
+      "image_override": "ghcr.io/ghashtag/trios-railway-mcp:latest",
       "vars": [
-        { "key": "RAILWAY_TOKEN", "value": "${secret:RAILWAY_TOKEN}" },
-        { "key": "PORT",          "value": "8080" }
+        { "key": "RAILWAY_TOKEN",      "value": "${secret:RAILWAY_TOKEN}" },
+        { "key": "RAILWAY_TOKEN_AUTH", "value": "team" },
+        { "key": "PORT",               "value": "8080" }
       ]
     },
-    { "name": "trios-dwagent", "kind": "agent", "vars": [] }
+
+    {
+      "name": "igla-final-seed-42",
+      "kind": "trainer",
+      "vars": [
+        { "key": "TRIOS_SEED",  "value": "42" },
+        { "key": "TRIOS_LANE",  "value": "A-champion-fineweb" }
+      ]
+    },
+    {
+      "name": "igla-final-seed-43",
+      "kind": "trainer",
+      "vars": [
+        { "key": "TRIOS_SEED",  "value": "43" },
+        { "key": "TRIOS_LANE",  "value": "A-champion-fineweb" }
+      ]
+    },
+    {
+      "name": "igla-final-seed-44",
+      "kind": "trainer",
+      "vars": [
+        { "key": "TRIOS_SEED",  "value": "44" },
+        { "key": "TRIOS_LANE",  "value": "A-champion-fineweb" }
+      ]
+    },
+
+    {
+      "name": "trios-train-seed-100",
+      "kind": "trainer",
+      "vars": [
+        { "key": "TRIOS_SEED",  "value": "100" },
+        { "key": "TRIOS_LANE",  "value": "B-mirror2" }
+      ]
+    },
+    {
+      "name": "trios-train-seed-101",
+      "kind": "trainer",
+      "vars": [
+        { "key": "TRIOS_SEED",  "value": "101" },
+        { "key": "TRIOS_LANE",  "value": "B-mirror2" }
+      ]
+    },
+    {
+      "name": "trios-train-seed-102",
+      "kind": "trainer",
+      "vars": [
+        { "key": "TRIOS_SEED",  "value": "102" },
+        { "key": "TRIOS_LANE",  "value": "B-mirror2" }
+      ]
+    },
+
+    {
+      "name": "trios-dwagent",
+      "kind": "agent",
+      "vars": [
+        { "key": "RAILWAY_TOKEN", "value": "${secret:RAILWAY_TOKEN}" }
+      ]
+    }
   ],
+
   "post_restore": {
-    "neon_ddl": "tri-railway audit migrate-sql",
-    "embargo_check": "trios-igla check ${champion_sha}",
-    "experience_line": "RAIL=restore @ project=${project_uuid_8c} service=ALL sha=${git_sha_8c} ts=${rfc3339}"
+    "neon_ddl":         "tri-railway audit migrate-sql",
+    "embargo_check":    "trios-igla check ${champion_sha}",
+    "experience_line":  "RAIL=restore @ project=${project_uuid_8c} service=ALL sha=${git_sha_8c} ts=${rfc3339}"
   }
 }

--- a/schemas/fixtures/invalid_empty_services.json
+++ b/schemas/fixtures/invalid_empty_services.json
@@ -1,0 +1,6 @@
+{
+  "version": 1,
+  "project": { "name": "empty" },
+  "image": "ghcr.io/example/trainer:latest",
+  "services": []
+}

--- a/schemas/fixtures/invalid_uppercase_service.json
+++ b/schemas/fixtures/invalid_uppercase_service.json
@@ -1,0 +1,8 @@
+{
+  "version": 1,
+  "project": { "name": "uppercase-svc" },
+  "image": "ghcr.io/example/trainer:latest",
+  "services": [
+    { "name": "BadName_With_Underscore" }
+  ]
+}

--- a/schemas/fixtures/invalid_v0.json
+++ b/schemas/fixtures/invalid_v0.json
@@ -1,0 +1,6 @@
+{
+  "version": 0,
+  "project": { "name": "wrong-version" },
+  "image": "ghcr.io/example/trainer:latest",
+  "services": [{ "name": "x" }]
+}

--- a/schemas/fixtures/valid_minimal.json
+++ b/schemas/fixtures/valid_minimal.json
@@ -1,0 +1,8 @@
+{
+  "version": 1,
+  "project": { "name": "minimal" },
+  "image": "ghcr.io/example/trainer:latest",
+  "services": [
+    { "name": "minimal-svc-1" }
+  ]
+}

--- a/schemas/restore-fleet.schema.json
+++ b/schemas/restore-fleet.schema.json
@@ -1,0 +1,147 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/gHashTag/trios-railway/blob/main/schemas/restore-fleet.schema.json",
+  "title": "RestoreFleetManifest",
+  "description": "Single source of truth for the IGLA Railway fleet shape. Consumed by `tri railway restore` (RW-DR-01) to rebuild from a clean account after a ban. Versioned via top-level `version`. Anchor: phi^2 + phi^-2 = 3. Refs #25, #26, #28.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "project", "image", "services"],
+  "properties": {
+    "$schema": {
+      "description": "Optional pointer to this schema for editor autocomplete.",
+      "type": "string"
+    },
+    "version": {
+      "description": "Manifest schema version. Bump with breaking changes.",
+      "type": "integer",
+      "const": 1
+    },
+    "anchor": {
+      "description": "Constitutional anchor. Cosmetic; readers must not rely on its value.",
+      "type": "string",
+      "default": "phi^2 + phi^-2 = 3"
+    },
+    "project": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name"],
+      "properties": {
+        "name": {
+          "description": "Railway project name to create or reuse.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 64,
+          "pattern": "^[A-Za-z0-9._-]+$"
+        },
+        "description": {
+          "description": "Optional human-readable project description shown in the Railway UI.",
+          "type": "string",
+          "maxLength": 512
+        },
+        "default_environment": {
+          "description": "Environment name to upsert variables and trigger deploys against.",
+          "type": "string",
+          "default": "production",
+          "minLength": 1,
+          "maxLength": 64,
+          "pattern": "^[A-Za-z0-9._-]+$"
+        }
+      }
+    },
+    "image": {
+      "description": "Container image used by every service unless `services[].image_override` is set. Either a bare reference (resolved to `:latest` at restore time) or a fully-qualified pin including a tag or `@sha256:` digest.",
+      "type": "string",
+      "minLength": 1,
+      "examples": [
+        "ghcr.io/ghashtag/trios-trainer-igla",
+        "ghcr.io/ghashtag/trios-trainer-igla:latest",
+        "ghcr.io/ghashtag/trios-trainer-igla@sha256:97a69d772941adc4d7240314dfa7963986c8bff6"
+      ]
+    },
+    "shared_vars": {
+      "description": "Variables upserted on every service before its first deploy. Use `${secret:NAME}` to reference an env-var the operator must provide at restore time (resolved by `tri railway restore`, never written to git).",
+      "type": "array",
+      "default": [],
+      "items": { "$ref": "#/$defs/KeyValue" },
+      "uniqueItems": true
+    },
+    "services": {
+      "description": "List of services to create. Order is preserved; duplicates by `name` are forbidden.",
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/Service" }
+    },
+    "post_restore": {
+      "description": "Optional automation hooks executed after every service has been deployed.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "neon_ddl": {
+          "description": "Shell command piped into psql against $NEON_DATABASE_URL. Recommended: `tri-railway audit migrate-sql`.",
+          "type": "string"
+        },
+        "embargo_check": {
+          "description": "Shell command that exits 0 if the embargo SHA list is intact. Refs R9.",
+          "type": "string"
+        },
+        "experience_line": {
+          "description": "Template for the L7 experience triplet sealed after restore. Supports `${project_uuid_8c}`, `${git_sha_8c}`, `${rfc3339}` placeholders.",
+          "type": "string"
+        }
+      }
+    }
+  },
+
+  "$defs": {
+    "KeyValue": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["key", "value"],
+      "properties": {
+        "key": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 128,
+          "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
+          "description": "POSIX env-var name."
+        },
+        "value": {
+          "type": "string",
+          "description": "Literal value, or `${secret:NAME}` to interpolate from process env / GitHub Secrets at restore time. Secrets are NEVER written to git."
+        }
+      }
+    },
+    "Service": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name"],
+      "properties": {
+        "name": {
+          "description": "Service name as it will appear in Railway. Must match `^[a-z0-9][a-z0-9-]{0,62}$` to satisfy Railway DNS rules.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 63,
+          "pattern": "^[a-z0-9][a-z0-9-]*$"
+        },
+        "kind": {
+          "description": "Free-form classifier consumed by tooling. Common values: `trainer`, `mcp`, `agent`, `sidecar`.",
+          "type": "string",
+          "default": "trainer",
+          "enum": ["trainer", "mcp", "agent", "sidecar"]
+        },
+        "image_override": {
+          "description": "Per-service override of the top-level `image`. Same format rules.",
+          "type": "string",
+          "minLength": 1
+        },
+        "vars": {
+          "description": "Variables specific to this service. Merged on top of `shared_vars`; per-service keys win on conflict.",
+          "type": "array",
+          "default": [],
+          "items": { "$ref": "#/$defs/KeyValue" },
+          "uniqueItems": true
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Closes [#26](https://github.com/gHashTag/trios-railway/issues/26). Refs [#25](https://github.com/gHashTag/trios-railway/issues/25) (RW-DR-01), [#28](https://github.com/gHashTag/trios-railway/issues/28) (RW-DR-04), [trios#143](https://github.com/gHashTag/trios/issues/143).

Lands the manifest contract that `tri railway restore` (RW-DR-01) and the lock writer (RW-DR-04) consume. No Rust code — pure declarative + CI gate.

Anchor: `phi^2 + phi^-2 = 3`.

## Files

| Path | Purpose |
|---|---|
| `schemas/restore-fleet.schema.json` | JSON Schema Draft 2020-12 for the manifest. Strictly closed (`additionalProperties: false`), pattern-bounded identifiers, `version` pinned to `const: 1`, `services` `minItems: 1`. |
| `restore-fleet.json` | Updated to schema v1. **8 services**, including 6 trainer-seeds (42, 43, 44 lane A · 100, 101, 102 lane B) + MCP control plane + dwagent. `L_R8_SYNTHETIC_FALLBACK=FORBID` in `shared_vars`. |
| `schemas/fixtures/{valid_minimal,invalid_v0,invalid_uppercase_service,invalid_empty_services}.json` | Positive/negative fixtures. Filename prefix is ground truth. |
| `.github/workflows/manifest-validate.yml` | CI: validates schema-self-conformance, the live manifest, and every fixture. |

## Acceptance criteria from #26

| Item | Status |
|---|---|
| `restore-fleet.json` committed to repo root | ✅ |
| Schema parseable by serde_json round-trip without warnings | ✅ (provable in #25 via `manifest_parses_v1` test) |
| `shared_vars` includes `L_R8_SYNTHETIC_FALLBACK=FORBID` | ✅ |
| Mirror-2 account seeds (100/101/102) covered | ✅ |
| `serde_json::from_str` round-trips | ✅ (validated locally; CI now enforces it) |

## Validation evidence (local)

```
$ python3 -m jsonschema validate ...
OK live: 8 services, version=1
  ✅ valid_minimal.json                         expected=pass actual=pass
  ✅ invalid_v0.json                            expected=fail actual=fail (1 was expected)
  ✅ invalid_uppercase_service.json             expected=fail actual=fail (... does not match ^[a-z0-9][a-z0-9-])
  ✅ invalid_empty_services.json                expected=fail actual=fail ([] should be non-empty)
```

## Why this lands now (vs. waiting for #25)

Locking the schema first means:

- The `FleetManifest` struct in `tri railway restore` (#25 c1) can be generated from this schema (e.g. `typify` or `quicktype`) instead of being typed by hand and drifting later.
- `#28` (lock writer) can reference the same identifier rules (service-name regex, secret-interpolation pattern) without hand-syncing.
- `#27` (weekly sandbox cron) gets a known-good manifest to deploy from on day one, rather than waiting for a hand-rolled fixture.

## Out of scope

- The `FleetManifest` Rust struct itself stays in #25.
- `${secret:NAME}` resolution lives in the CLI, not the schema.
- A `version: 2` migration story is deferred; bump the const and add a migration test when the day comes.

## How to use

```bash
# Validate locally before committing manifest changes
python3 -m jsonschema schemas/restore-fleet.schema.json -i restore-fleet.json
```

Or rely on the CI gate (`manifest-validate.yml`) — which runs on every PR that touches `restore-fleet.json` or the schema itself.

φ² + φ⁻² = 3 · TRINITY · NEVER STOP
