### PR TITLE
feat(dr): alive attention fleet manifest — ATTN_SCALE=0.3, ATTN_SEQ=16

### DIFF
--- a/restore-fleet.json
+++ b/restore-fleet.json
@@ -14,11 +14,14 @@
 
   "shared_vars": [
     { "key": "RUST_LOG",                "value": "info" },
-    { "key": "TRIOS_HIDDEN",            "value": "384" },
+    { "key": "TRIOS_HIDDEN",            "value": "828" },
     { "key": "TRIOS_LR",                "value": "0.003" },
     { "key": "TRIOS_OPTIMIZER",         "value": "adamw" },
-    { "key": "TRIOS_STEPS",             "value": "60000" },
+    { "key": "TRIOS_STEPS",             "value": "81000" },
     { "key": "TRIOS_ATTN_LAYERS",       "value": "2" },
+    { "key": "TRIOS_ATTN_SCALE",        "value": "0.3" },
+    { "key": "TRIOS_ATTN_SEQ",          "value": "16" },
+    { "key": "TRIOS_GF16_DISABLE",      "value": "1" },
     { "key": "L_R8_SYNTHETIC_FALLBACK", "value": "FORBID" },
     { "key": "NEON_DATABASE_URL",       "value": "${secret:NEON_DATABASE_URL}" }
   ],


### PR DESCRIPTION
## Summary

- Updates `restore-fleet.json` with new env vars from [trios-trainer-igla#40](https://github.com/gHashTag/trios-trainer-igla/pull/40)
- **BREAKTHROUGH**: attention was completely inert at default `scale=0.1`; now set to `0.3` with `ATTN_SEQ=16`
- Hidden upgraded `384→828`, steps `60000→81000`

## New shared vars

| Var | Value | Purpose |
|-----|-------|---------|
| `TRIOS_ATTN_SCALE` | 0.3 | Attention contribution (was inert at 0.1) |
| `TRIOS_ATTN_SEQ` | 16 | Attention context positions (was 8) |
| `TRIOS_GF16_DISABLE` | 1 | Disable weight quantization |

## Evidence

A/B test at h=828, seed=43, 2000 steps: **-0.110 BPB** (2.8712 → 2.7612).

Closes #44, refs #45, #46, #43

Agent: GENERAL · Soul-name: NeedleFinder
`phi^2 + phi^-2 = 3`