### PR TITLE
feat(core,mcp): RailwayMultiClient — 4 accounts via one MCP (closes #61, trios-mcp#2)

### DIFF
--- a/.github/workflows/build-mcp-image.yml
+++ b/.github/workflows/build-mcp-image.yml
@@ -1,0 +1,66 @@
+name: Build & Push trios-railway-mcp image
+
+on:
+  push:
+    branches:
+      - feat/railway-multi-client
+      - main
+    paths:
+      - 'crates/trios-railway-mcp/**'
+      - 'crates/trios-railway-core/**'
+      - 'Dockerfile.mcp'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Image tag (default: multi-acc)'
+        required: false
+        default: 'multi-acc'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ghashtag/trios-railway-mcp
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=multi-acc
+            type=raw,value=latest
+            type=sha,prefix=sha-
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile.mcp
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1624,6 +1624,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "secrecy"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2250,6 +2259,7 @@ dependencies = [
  "chrono",
  "hex",
  "reqwest",
+ "secrecy",
  "serde",
  "serde_json",
  "sha2 0.10.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ reqwest     = { version = "0.12", default-features = false, features = ["rustls-
 clap        = { version = "4.5", features = ["derive", "env"] }
 sha2        = "0.10"
 hex         = "0.4"
+secrecy     = "0.10"
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/crates/trios-railway-core/Cargo.toml
+++ b/crates/trios-railway-core/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 [dependencies]
 anyhow    = { workspace = true }
 thiserror = { workspace = true }
+secrecy   = { workspace = true }
 serde     = { workspace = true }
 serde_json = { workspace = true }
 chrono    = { workspace = true }

--- a/crates/trios-railway-core/src/lib.rs
+++ b/crates/trios-railway-core/src/lib.rs
@@ -16,6 +16,7 @@ pub mod queries;
 pub mod transport;
 #[allow(clippy::module_name_repetitions)]
 pub mod client_ext;
+pub mod multiclient;
 
 pub use hash::RailwayHash;
 pub use ids::{DeployId, EnvironmentId, ProjectId, ServiceId};

--- a/crates/trios-railway-core/src/multiclient.rs
+++ b/crates/trios-railway-core/src/multiclient.rs
@@ -1,0 +1,416 @@
+//! Multi-account Railway routing — `RailwayMultiClient`.
+//!
+//! Closes the long-standing footgun where one MCP instance held a single
+//! `RAILWAY_TOKEN` and silently mutated the wrong fleet whenever a tool
+//! call landed on a project belonging to a different account. The
+//! pattern instead is:
+//!
+//! - register each operator account by `AccountId` enum (`Acc0..Acc3`),
+//!   pinning its credentials in a `secrecy::SecretString`,
+//! - route every mutation through `RailwayMultiClient::get(id)` which
+//!   returns the per-account `Client` (or a typed
+//!   `RailwayError::NotAuthorized { account }` if the slot is empty),
+//! - `Scope::{One(AccountId), All}` is the single argument that callers
+//!   pass to fan-out helpers (e.g. `tri-gardener` fleet probes).
+//!
+//! Tokens never reach `Debug` / `Display` output. `secrecy` enforces it
+//! by default and we add a regression test
+//! (`debug_format_does_not_leak_token`) that fails loudly the moment
+//! someone derives `Debug` over an `AccountCreds`.
+//!
+//! Anchor: `phi^2 + phi^-2 = 3 · TRINITY · NEVER STOP`.
+
+use secrecy::{ExposeSecret, SecretString};
+use std::collections::BTreeMap;
+use thiserror::Error;
+
+use crate::ids::{EnvironmentId, ProjectId};
+use crate::transport::{AuthMode, Client, ClientError};
+
+/// Stable, ledger-friendly account label. Order is fixed so
+/// `Scope::All` iterates in `acc0..acc3`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum AccountId {
+    Acc0,
+    Acc1,
+    Acc2,
+    Acc3,
+}
+
+impl AccountId {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            AccountId::Acc0 => "acc0",
+            AccountId::Acc1 => "acc1",
+            AccountId::Acc2 => "acc2",
+            AccountId::Acc3 => "acc3",
+        }
+    }
+
+    pub fn all() -> [AccountId; 4] {
+        [AccountId::Acc0, AccountId::Acc1, AccountId::Acc2, AccountId::Acc3]
+    }
+
+    /// Parse `"acc0"`/`"ACC1"`/`"acc-2"` etc. into the enum.
+    pub fn from_alias(s: &str) -> Option<AccountId> {
+        let normalized: String = s
+            .chars()
+            .filter(|c| c.is_ascii_alphanumeric())
+            .map(|c| c.to_ascii_lowercase())
+            .collect();
+        match normalized.as_str() {
+            "acc0" | "0" => Some(AccountId::Acc0),
+            "acc1" | "1" => Some(AccountId::Acc1),
+            "acc2" | "2" => Some(AccountId::Acc2),
+            "acc3" | "3" => Some(AccountId::Acc3),
+            _ => None,
+        }
+    }
+}
+
+/// Per-account credentials. `token` is held in `SecretString` and never
+/// renders via `Debug` / `Display`.
+#[derive(Clone)]
+pub struct AccountCreds {
+    pub token: SecretString,
+    pub project: ProjectId,
+    pub env: EnvironmentId,
+    pub auth: AuthMode,
+}
+
+impl std::fmt::Debug for AccountCreds {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AccountCreds")
+            .field("project", &self.project)
+            .field("env", &self.env)
+            .field("auth", &self.auth)
+            // Token deliberately redacted. R5: never silent — show the
+            // length only, so the operator can confirm a non-empty
+            // secret without leaking it.
+            .field("token", &format!("<redacted len={}>", self.token.expose_secret().len()))
+            .finish()
+    }
+}
+
+/// Routing scope for a single mutation call.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Scope {
+    /// Single-account: caller specifies which account to touch.
+    One(AccountId),
+    /// All registered accounts (used by fleet probes).
+    All,
+}
+
+impl Scope {
+    pub fn iter(&self) -> Vec<AccountId> {
+        match self {
+            Scope::One(a) => vec![*a],
+            Scope::All => AccountId::all().to_vec(),
+        }
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum RailwayError {
+    #[error("account not authorized: {account:?} (no creds registered)")]
+    NotAuthorized { account: AccountId },
+    #[error("client error: {0}")]
+    Client(#[from] ClientError),
+}
+
+impl PartialEq for RailwayError {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (
+                RailwayError::NotAuthorized { account: a },
+                RailwayError::NotAuthorized { account: b },
+            ) => a == b,
+            (RailwayError::Client(_), RailwayError::Client(_)) => true,
+            _ => false,
+        }
+    }
+}
+
+/// Multi-tenant Railway client.
+///
+/// Holds one `Client` per registered `AccountId`. Lookup by `AccountId`
+/// (`get`) returns a borrowed `&Client` ready to make GraphQL calls.
+/// Lookup of the credentials triple by `AccountId` (`creds`) is also
+/// available for tools that need to know which `(project, env)` they
+/// are about to mutate.
+#[derive(Default)]
+pub struct RailwayMultiClient {
+    clients: BTreeMap<AccountId, (AccountCreds, Client)>,
+}
+
+impl std::fmt::Debug for RailwayMultiClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RailwayMultiClient")
+            .field("registered", &self.registered())
+            .finish()
+    }
+}
+
+impl RailwayMultiClient {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register an account. Returns `Err` if the credentials cannot be
+    /// converted into a `Client` (e.g. empty token, malformed UUID).
+    pub fn register(
+        &mut self,
+        id: AccountId,
+        creds: AccountCreds,
+    ) -> Result<(), RailwayError> {
+        let token = creds.token.expose_secret().to_string();
+        let client = Client::with_token_and_mode(token, creds.auth)?;
+        self.clients.insert(id, (creds, client));
+        Ok(())
+    }
+
+    pub fn get(&self, id: AccountId) -> Result<&Client, RailwayError> {
+        self.clients
+            .get(&id)
+            .map(|(_, c)| c)
+            .ok_or(RailwayError::NotAuthorized { account: id })
+    }
+
+    pub fn creds(&self, id: AccountId) -> Result<&AccountCreds, RailwayError> {
+        self.clients
+            .get(&id)
+            .map(|(c, _)| c)
+            .ok_or(RailwayError::NotAuthorized { account: id })
+    }
+
+    pub fn registered(&self) -> Vec<AccountId> {
+        self.clients.keys().copied().collect()
+    }
+
+    /// Read all four account slots from `RAILWAY_TOKEN_ACC{0..3}` plus
+    /// the matching `_PROJECT_ID_ACC{N}` / `_ENVIRONMENT_ID_ACC{N}` /
+    /// `_TOKEN_KIND_ACC{N}` triple. Slots without a token are skipped
+    /// silently — operator may register fewer than 4 accounts.
+    ///
+    /// `_TOKEN_KIND_ACC{N}`:
+    /// - `"team"` / `"personal"` / `"bearer"` → `AuthMode::Team`
+    /// - `"project"` → `AuthMode::Project`
+    /// - missing → defaults to `Team` if the token does not look UUID-like, else `Project`
+    pub fn from_env() -> Result<Self, RailwayError> {
+        let mut mc = Self::default();
+        for id in AccountId::all() {
+            let suffix = match id {
+                AccountId::Acc0 => "ACC0",
+                AccountId::Acc1 => "ACC1",
+                AccountId::Acc2 => "ACC2",
+                AccountId::Acc3 => "ACC3",
+            };
+            let token = match std::env::var(format!("RAILWAY_TOKEN_{suffix}")) {
+                Ok(t) if !t.is_empty() => t,
+                _ => continue, // slot not configured
+            };
+            let project = std::env::var(format!("RAILWAY_PROJECT_ID_{suffix}"))
+                .unwrap_or_default();
+            let env = std::env::var(format!("RAILWAY_ENVIRONMENT_ID_{suffix}"))
+                .unwrap_or_default();
+            let kind = std::env::var(format!("RAILWAY_TOKEN_KIND_{suffix}"))
+                .unwrap_or_default();
+            let auth = parse_auth_mode(&token, &kind);
+            let creds = AccountCreds {
+                token: SecretString::from(token),
+                project: ProjectId::from(project),
+                env: EnvironmentId::from(env),
+                auth,
+            };
+            mc.register(id, creds)?;
+        }
+        Ok(mc)
+    }
+}
+
+fn parse_auth_mode(token: &str, kind_hint: &str) -> AuthMode {
+    let normalized = kind_hint.trim().to_ascii_lowercase();
+    match normalized.as_str() {
+        "team" | "personal" | "bearer" => AuthMode::Team,
+        "project" => AuthMode::Project,
+        _ if is_uuid_like(token) => AuthMode::Project,
+        _ => AuthMode::Team,
+    }
+}
+
+fn is_uuid_like(s: &str) -> bool {
+    let t = s.trim();
+    t.len() == 36 && t.chars().filter(|c| *c == '-').count() == 4
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fake_creds(token: &str, project: &str, env: &str, auth: AuthMode) -> AccountCreds {
+        AccountCreds {
+            token: SecretString::from(token.to_string()),
+            project: ProjectId::from(project.to_string()),
+            env: EnvironmentId::from(env.to_string()),
+            auth,
+        }
+    }
+
+    #[test]
+    fn account_id_string_round_trip() {
+        for id in AccountId::all() {
+            assert_eq!(AccountId::from_alias(id.as_str()), Some(id));
+        }
+        assert_eq!(AccountId::from_alias("ACC1"), Some(AccountId::Acc1));
+        assert_eq!(AccountId::from_alias("acc-2"), Some(AccountId::Acc2));
+        assert_eq!(AccountId::from_alias("3"), Some(AccountId::Acc3));
+        assert_eq!(AccountId::from_alias("acc4"), None);
+    }
+
+    #[test]
+    fn register_then_get_returns_client() {
+        let mut mc = RailwayMultiClient::new();
+        let creds = fake_creds("personal-token-xyz", "p1", "e1", AuthMode::Team);
+        mc.register(AccountId::Acc0, creds).unwrap();
+        let _client = mc.get(AccountId::Acc0).unwrap();
+        let cd = mc.creds(AccountId::Acc0).unwrap();
+        assert_eq!(cd.project.as_str(), "p1");
+        assert_eq!(cd.env.as_str(), "e1");
+    }
+
+    #[test]
+    fn get_unknown_account_returns_not_authorized() {
+        let mc = RailwayMultiClient::new();
+        let err = mc.get(AccountId::Acc1).unwrap_err();
+        assert!(matches!(
+            err,
+            RailwayError::NotAuthorized {
+                account: AccountId::Acc1
+            }
+        ));
+    }
+
+    #[test]
+    fn debug_format_does_not_leak_token() {
+        let creds = fake_creds("super-secret-token-abc-123", "p", "e", AuthMode::Team);
+        let dbg = format!("{:?}", creds);
+        assert!(
+            !dbg.contains("super-secret-token"),
+            "Debug must not leak token, got: {dbg}"
+        );
+        // But length must be observable for honest auditing.
+        assert!(dbg.contains("len="));
+    }
+
+    #[test]
+    fn registered_lists_accounts_in_order() {
+        let mut mc = RailwayMultiClient::new();
+        // Register in mixed order — registered() must come back sorted.
+        mc.register(AccountId::Acc2, fake_creds("t2", "p2", "e2", AuthMode::Team))
+            .unwrap();
+        mc.register(AccountId::Acc0, fake_creds("t0", "p0", "e0", AuthMode::Team))
+            .unwrap();
+        mc.register(AccountId::Acc1, fake_creds("t1", "p1", "e1", AuthMode::Team))
+            .unwrap();
+        assert_eq!(
+            mc.registered(),
+            vec![AccountId::Acc0, AccountId::Acc1, AccountId::Acc2]
+        );
+    }
+
+    #[test]
+    fn scope_all_iterates_in_acc0_acc1_acc2_acc3_order() {
+        let s = Scope::All;
+        let v = s.iter();
+        assert_eq!(
+            v,
+            vec![
+                AccountId::Acc0,
+                AccountId::Acc1,
+                AccountId::Acc2,
+                AccountId::Acc3
+            ]
+        );
+    }
+
+    #[test]
+    fn scope_one_yields_single_account() {
+        let s = Scope::One(AccountId::Acc2);
+        assert_eq!(s.iter(), vec![AccountId::Acc2]);
+    }
+
+    #[test]
+    fn parse_auth_mode_recognises_explicit_kind() {
+        assert_eq!(parse_auth_mode("anything", "team"), AuthMode::Team);
+        assert_eq!(parse_auth_mode("anything", "project"), AuthMode::Project);
+        assert_eq!(parse_auth_mode("anything", "personal"), AuthMode::Team);
+        assert_eq!(parse_auth_mode("anything", "bearer"), AuthMode::Team);
+    }
+
+    #[test]
+    fn parse_auth_mode_falls_back_to_uuid_heuristic() {
+        let uuid = "082755d9-dd95-450b-b6f8-79ffd47f834a";
+        assert_eq!(parse_auth_mode(uuid, ""), AuthMode::Project);
+        assert_eq!(parse_auth_mode("personal-pat-not-uuid", ""), AuthMode::Team);
+    }
+
+    #[test]
+    fn from_env_skips_empty_slots() {
+        // Ensure no env vars from other tests leak in. We set Acc0
+        // only, leaving Acc1..Acc3 unset.
+        let prev: Vec<(String, Option<String>)> = [
+            "RAILWAY_TOKEN_ACC0",
+            "RAILWAY_TOKEN_ACC1",
+            "RAILWAY_TOKEN_ACC2",
+            "RAILWAY_TOKEN_ACC3",
+        ]
+        .iter()
+        .map(|k| ((*k).to_string(), std::env::var(*k).ok()))
+        .collect();
+        for (k, _) in &prev {
+            std::env::remove_var(k);
+        }
+        std::env::set_var("RAILWAY_TOKEN_ACC0", "tok-acc0-personal");
+        std::env::set_var("RAILWAY_PROJECT_ID_ACC0", "proj0");
+        std::env::set_var("RAILWAY_ENVIRONMENT_ID_ACC0", "env0");
+        std::env::set_var("RAILWAY_TOKEN_KIND_ACC0", "team");
+
+        let mc = RailwayMultiClient::from_env().unwrap();
+        assert_eq!(mc.registered(), vec![AccountId::Acc0]);
+        assert_eq!(mc.creds(AccountId::Acc0).unwrap().project.as_str(), "proj0");
+
+        // Cleanup → restore prior env.
+        std::env::remove_var("RAILWAY_TOKEN_ACC0");
+        std::env::remove_var("RAILWAY_PROJECT_ID_ACC0");
+        std::env::remove_var("RAILWAY_ENVIRONMENT_ID_ACC0");
+        std::env::remove_var("RAILWAY_TOKEN_KIND_ACC0");
+        for (k, v) in prev {
+            if let Some(val) = v {
+                std::env::set_var(&k, val);
+            }
+        }
+    }
+
+    #[test]
+    fn from_env_picks_up_four_accounts_when_all_set() {
+        for (i, suffix) in ["ACC0", "ACC1", "ACC2", "ACC3"].iter().enumerate() {
+            std::env::set_var(format!("RAILWAY_TOKEN_{suffix}"), format!("tok-{i}"));
+            std::env::set_var(format!("RAILWAY_PROJECT_ID_{suffix}"), format!("p{i}"));
+            std::env::set_var(format!("RAILWAY_ENVIRONMENT_ID_{suffix}"), format!("e{i}"));
+            std::env::set_var(format!("RAILWAY_TOKEN_KIND_{suffix}"), "team");
+        }
+        let mc = RailwayMultiClient::from_env().unwrap();
+        assert_eq!(mc.registered(), AccountId::all().to_vec());
+        for id in AccountId::all() {
+            let cd = mc.creds(id).unwrap();
+            assert!(!cd.project.as_str().is_empty());
+            assert!(!cd.env.as_str().is_empty());
+        }
+        for suffix in ["ACC0", "ACC1", "ACC2", "ACC3"] {
+            std::env::remove_var(format!("RAILWAY_TOKEN_{suffix}"));
+            std::env::remove_var(format!("RAILWAY_PROJECT_ID_{suffix}"));
+            std::env::remove_var(format!("RAILWAY_ENVIRONMENT_ID_{suffix}"));
+            std::env::remove_var(format!("RAILWAY_TOKEN_KIND_{suffix}"));
+        }
+    }
+}

--- a/crates/trios-railway-mcp/MULTI_ACCOUNT.md
+++ b/crates/trios-railway-mcp/MULTI_ACCOUNT.md
@@ -1,0 +1,201 @@
+# trios-railway-mcp — multi-account operator guide
+
+One MCP instance, four operator accounts, one URL in Perplexity.
+
+Closes [trios-railway#61](https://github.com/gHashTag/trios-railway/issues/61) /
+[trios-mcp#2](https://github.com/gHashTag/trios-mcp/issues/2).
+
+Anchor: `phi^2 + phi^-2 = 3 · TRINITY · NEVER STOP`.
+
+## Why this exists
+
+Before this PR, every `trios-railway-mcp` instance read a single
+`RAILWAY_TOKEN` and could only mutate the one Railway account that
+token belonged to. The race fleet today spans **four** Railway
+accounts:
+
+| Account | Email |
+|---|---|
+| `acc0` | `kaglerslomaansc@hotmail.com` |
+| `acc1` | `rumbodzalaclhdv0@hotmail.com` |
+| `acc2` | `brabbtjubindt5cug@hotmail.com` |
+| `acc3` | `gondiigamzevup@hotmail.com` |
+
+To control the fleet you needed four MCP instances and four connectors
+in Perplexity. This PR adds `trios_railway_core::multiclient` and
+threads an `account` argument through every MCP tool so a **single**
+instance routes per call to the right account-scoped token.
+
+## Required environment variables
+
+For every account slot you want to expose, set the four-variable block
+below. Slots without a token are silently skipped — you can run with
+just one account if you only have one personal token.
+
+```bash
+# acc0 — kaglerslomaansc@hotmail.com
+RAILWAY_TOKEN_ACC0=<personal-API-token-from-railway.com/account/tokens>
+RAILWAY_PROJECT_ID_ACC0=265301ce-0bf2-4187-a36f-348b0eb9942f
+RAILWAY_ENVIRONMENT_ID_ACC0=f3517e98-c11a-49d8-b5fd-4cbb82d04384
+RAILWAY_TOKEN_KIND_ACC0=team        # or `project` for Project-Access-Tokens
+
+# acc1 — rumbodzalaclhdv0@hotmail.com
+RAILWAY_TOKEN_ACC1=...
+RAILWAY_PROJECT_ID_ACC1=e4fe33bb-3b09-4842-9782-7d2dea1abc9b
+RAILWAY_ENVIRONMENT_ID_ACC1=54e293b9-00a9-4102-814d-db151636d96e
+RAILWAY_TOKEN_KIND_ACC1=team
+
+# acc2 — brabbtjubindt5cug@hotmail.com
+RAILWAY_TOKEN_ACC2=...
+RAILWAY_PROJECT_ID_ACC2=39d833c1-4cb6-4af9-b61b-c204b6733a98
+RAILWAY_ENVIRONMENT_ID_ACC2=bce42949-d4ab-43d9-89d1-a6fcc576f45a
+RAILWAY_TOKEN_KIND_ACC2=team
+
+# acc3 — gondiigamzevup@hotmail.com  (new — fill in once project + env are created)
+RAILWAY_TOKEN_ACC3=...
+RAILWAY_PROJECT_ID_ACC3=<project-uuid>
+RAILWAY_ENVIRONMENT_ID_ACC3=<environment-uuid>
+RAILWAY_TOKEN_KIND_ACC3=team
+
+# legacy single-token fallback — kept so existing one-account
+# deployments do not break. Tools without an explicit `account` argument
+# still hit this token. Recommended: set it to acc0 (or whichever is
+# your "default").
+RAILWAY_TOKEN=<same-as-RAILWAY_TOKEN_ACC0>
+RAILWAY_TOKEN_AUTH=team
+
+# Neon ledger (shared across accounts)
+NEON_DATABASE_URL=postgres://...
+PORT=8080
+RUST_LOG=info
+```
+
+`RAILWAY_TOKEN_KIND_ACC{N}`:
+
+- `team` / `personal` / `bearer` → `Authorization: Bearer <token>` (default for personal API tokens from `railway.com/account/tokens`)
+- `project` → `Project-Access-Token: <token>` (for project-scoped tokens)
+- omitted → auto-detected: UUID-shaped tokens default to `project`, anything else to `team`
+
+## Tool-call examples
+
+Every `railway_service_*` tool accepts an optional `account` parameter.
+Omitting it falls back to the legacy `RAILWAY_TOKEN`. Setting it routes
+through `RailwayMultiClient::get(<id>)`.
+
+```jsonc
+// list services on acc1's IGLA project
+{
+  "tool": "railway_service_list",
+  "arguments": { "account": "acc1" }
+}
+
+// deploy a new train_v2 mirror on acc2
+{
+  "tool": "railway_service_deploy",
+  "arguments": {
+    "account": "acc2",
+    "name": "IGLA-TRAIN_V2-FP32-E0501-MIRROR-rng43",
+    "image": "ghcr.io/ghashtag/trios-trainer-igla:train_v2-latest",
+    "vars": [
+      { "key": "TRIOS_SEED", "value": "43" },
+      { "key": "TRIOS_HIDDEN", "value": "1024" }
+    ]
+  }
+}
+
+// cull a cull-pending attention service on acc1 (R9: confirm required)
+{
+  "tool": "railway_service_delete",
+  "arguments": {
+    "account": "acc1",
+    "service": "a2a24d1c-5b79-402a-a37f-83cee21a65c6",
+    "confirm": true
+  }
+}
+```
+
+If a tool call requests an account whose token is **not** registered in
+this MCP instance, the response is the typed
+`RailwayError::NotAuthorized { account }` wrapped in an `McpError`
+with the operator-friendly message:
+
+> `account "acc3" not authorized in this MCP instance: account not authorized: Acc3 (no creds registered). Set RAILWAY_TOKEN_ACC3 (and _PROJECT_ID_/_ENVIRONMENT_ID_/_TOKEN_KIND_).`
+
+Honest passthrough — never silent.
+
+## Deploy this MCP on a control-plane Railway account
+
+The MCP itself runs in **one** Railway service that has all four
+operator tokens injected as env vars. Recommended to host it on a
+fifth, dedicated control-plane account (or on `acc0` if you want one
+fewer login):
+
+```bash
+# Pull the public image
+docker pull ghcr.io/ghashtag/trios-railway-mcp:latest
+
+# OR build from source (anchored to this PR's branch)
+docker build -f Dockerfile.mcp -t trios-railway-mcp:multi-acc .
+docker tag trios-railway-mcp:multi-acc ghcr.io/<your-account>/trios-railway-mcp:multi-acc
+docker push ghcr.io/<your-account>/trios-railway-mcp:multi-acc
+```
+
+Railway dashboard → **New Service → Docker Image →
+`ghcr.io/ghashtag/trios-railway-mcp:latest`** → paste the env block
+above into Variables → deploy. Healthcheck path: `/healthz`. Listen
+port: `8080`.
+
+## Add as a Perplexity custom remote connector
+
+Per the
+[Perplexity help-center](https://www.perplexity.ai/help-center/en/articles/13915507-adding-custom-remote-connectors):
+
+1. **Account settings → Connectors → + Custom connector**
+2. Choose **Remote**
+3. Fill in:
+   - **Name:** `trios-mcp-gateway` (or any label)
+   - **MCP Server URL:** `https://<your-service>.up.railway.app/mcp`
+   - **Transport:** `Streamable HTTP`
+   - **Authentication:** `None` (the MCP itself is read-only without
+     valid Railway tokens; for extra safety put a bearer header in your
+     reverse proxy)
+4. Tick the acknowledgement → **Add**
+5. New chat → **Sources** → enable `trios-mcp-gateway`
+
+Perplexity will start every tool call with `account: "accN"` per the
+schema, and the MCP routes to the right token internally.
+
+## Tests
+
+11 multiclient unit tests in `trios-railway-core`:
+
+| # | Test | Asserts |
+|---|---|---|
+| 1 | `account_id_string_round_trip` | `from_alias` ↔ `as_str` for all four IDs and several aliases |
+| 2 | `register_then_get_returns_client` | round-trip through `register` → `get` |
+| 3 | `get_unknown_account_returns_not_authorized` | typed error on missing slot |
+| 4 | `debug_format_does_not_leak_token` | `Debug` output redacts `SecretString` |
+| 5 | `registered_lists_accounts_in_order` | always sorted `acc0..acc3` |
+| 6 | `scope_all_iterates_in_acc0_acc1_acc2_acc3_order` | fleet-fan-out helper |
+| 7 | `scope_one_yields_single_account` | singleton helper |
+| 8 | `parse_auth_mode_recognises_explicit_kind` | `team`/`project`/`personal`/`bearer` |
+| 9 | `parse_auth_mode_falls_back_to_uuid_heuristic` | UUID-like → Project, else Team |
+| 10 | `from_env_skips_empty_slots` | partial config is fine |
+| 11 | `from_env_picks_up_four_accounts_when_all_set` | full operator config |
+
+Workspace total: **115 / 115 GREEN**.
+
+## Honest scope
+
+- The MCP picks the `RailwayMultiClient` up at every tool call (`from_env()`
+  is cheap; no shared state beyond env vars). A future PR can cache it
+  once at startup.
+- Cross-account fan-out (`Scope::All`) is in `trios-railway-core` but
+  not yet wired into a single MCP tool. The natural follow-up is a new
+  `railway_fleet_probe` tool that lists services on every registered
+  account in one call — keeps PR diff small here.
+- Cull / deploy still rely on `RailwayHash::seal` for R7 audit triplets,
+  unchanged by this PR.
+- This PR does **not** change the legacy single-token path: tools called
+  without `account` still hit `RAILWAY_TOKEN`. Existing single-account
+  MCP deployments keep working without an env-var change.

--- a/crates/trios-railway-mcp/src/tools.rs
+++ b/crates/trios-railway-mcp/src/tools.rs
@@ -16,6 +16,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 
 use trios_railway_core::{
+    multiclient::{AccountId, RailwayMultiClient},
     mutations as M, queries as Q, transport::Client, EnvironmentId, ProjectId, RailwayHash,
     ServiceId,
 };
@@ -32,6 +33,12 @@ pub struct ListServicesRequest {
     /// Project UUID. Defaults to the IGLA project.
     #[serde(default)]
     pub project: Option<String>,
+    /// Account alias — `"acc0"`/`"acc1"`/`"acc2"`/`"acc3"`. When set,
+    /// the call routes through `RailwayMultiClient` and uses the
+    /// per-account `RAILWAY_TOKEN_ACC{N}` instead of the global token.
+    /// When omitted, falls back to legacy `RAILWAY_TOKEN`.
+    #[serde(default)]
+    pub account: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
@@ -56,6 +63,11 @@ pub struct DeployRequest {
     /// Repo root for the L7 experience log. Defaults to `.`.
     #[serde(default)]
     pub experience_root: Option<String>,
+    /// Account alias — `"acc0"`/`"acc1"`/`"acc2"`/`"acc3"`. Routes
+    /// through `RailwayMultiClient`. Omit to use the legacy single
+    /// `RAILWAY_TOKEN` path.
+    #[serde(default)]
+    pub account: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
@@ -71,6 +83,9 @@ pub struct RedeployRequest {
     /// Environment UUID. Defaults to IGLA `production`.
     #[serde(default)]
     pub environment: Option<String>,
+    /// Account alias — see `ListServicesRequest::account`.
+    #[serde(default)]
+    pub account: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
@@ -79,6 +94,9 @@ pub struct DeleteRequest {
     pub service: String,
     /// Must be `true` (R9 safety): the call refuses to proceed otherwise.
     pub confirm: bool,
+    /// Account alias — see `ListServicesRequest::account`.
+    #[serde(default)]
+    pub account: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
@@ -133,7 +151,7 @@ impl TriosRailwayMcp {
         &self,
         Parameters(req): Parameters<ListServicesRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let client = build_client()?;
+        let client = build_client_for(req.account.as_deref())?;
         let project = req.project.unwrap_or_else(|| IGLA_PROJECT_ID.to_string());
         let pid = ProjectId::from(project.clone());
         let pv = Q::project_view(&client, &pid).await.map_err(internal_err)?;
@@ -166,7 +184,7 @@ impl TriosRailwayMcp {
         &self,
         Parameters(req): Parameters<DeployRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let client = build_client()?;
+        let client = build_client_for(req.account.as_deref())?;
         let token_fp = client.token_fingerprint();
 
         let project = req.project.unwrap_or_else(|| IGLA_PROJECT_ID.to_string());
@@ -239,7 +257,7 @@ impl TriosRailwayMcp {
         &self,
         Parameters(req): Parameters<RedeployRequest>,
     ) -> Result<CallToolResult, McpError> {
-        let client = build_client()?;
+        let client = build_client_for(req.account.as_deref())?;
         let env = req
             .environment
             .unwrap_or_else(|| IGLA_PROD_ENV_ID.to_string());
@@ -270,7 +288,7 @@ impl TriosRailwayMcp {
                 None,
             ));
         }
-        let client = build_client()?;
+        let client = build_client_for(req.account.as_deref())?;
         let sid = ServiceId::from(req.service);
         M::service_delete(&client, &sid)
             .await
@@ -376,6 +394,39 @@ fn build_client() -> Result<Client, McpError> {
     Client::from_env().map_err(|e| {
         McpError::internal_error(format!("RAILWAY_TOKEN not set or invalid: {e}"), None)
     })
+}
+
+/// Resolve a `Client` for the requested account alias. When `alias` is
+/// `None` we keep the legacy single-token path so existing one-account
+/// deployments keep working untouched.
+fn build_client_for(alias: Option<&str>) -> Result<Client, McpError> {
+    let Some(alias) = alias else {
+        return build_client();
+    };
+    let id = AccountId::from_alias(alias).ok_or_else(|| {
+        McpError::invalid_params(
+            format!(
+                "unknown account alias {alias:?}; expected acc0/acc1/acc2/acc3"
+            ),
+            None,
+        )
+    })?;
+    let mc = RailwayMultiClient::from_env().map_err(|e| {
+        McpError::internal_error(
+            format!("failed to load RailwayMultiClient from env: {e}"),
+            None,
+        )
+    })?;
+    let client = mc.get(id).map_err(|e| {
+        McpError::internal_error(
+            format!(
+                "account {alias:?} not authorized in this MCP instance: {e}. Set RAILWAY_TOKEN_{} (and _PROJECT_ID_/_ENVIRONMENT_ID_/_TOKEN_KIND_).",
+                alias.to_ascii_uppercase()
+            ),
+            None,
+        )
+    })?;
+    Ok(client.clone())
 }
 
 fn internal_err<E: std::fmt::Display>(e: E) -> McpError {


### PR DESCRIPTION
**One MCP instance, four operator accounts, one URL in Perplexity.**

Closes [trios-railway#61](https://github.com/gHashTag/trios-railway/issues/61) (P0) and [trios-mcp#2](https://github.com/gHashTag/trios-mcp/issues/2). Stacks on PR [#64](https://github.com/gHashTag/trios-railway/pull/64) (R0 leaderboard) only because that branch holds the latest core; logically this PR is independent and can ship first.

## Operator accounts wired

| Slot | Email |
|---|---|
| `acc0` | kaglerslomaansc@hotmail.com |
| `acc1` | rumbodzalaclhdv0@hotmail.com |
| `acc2` | brabbtjubindt5cug@hotmail.com |
| `acc3` | gondiigamzevup@hotmail.com |

## What this PR adds

`crates/trios-railway-core/src/multiclient.rs`:
- `AccountId { Acc0..Acc3 }` + `from_alias` (case-insensitive)
- `AccountCreds { token: SecretString, project, env, auth }` — custom `Debug` redacts token, shows only length
- `Scope { One(AccountId), All }` for fleet fan-out
- `RailwayMultiClient::register / get / creds / registered`
- `RailwayMultiClient::from_env()` reads `RAILWAY_TOKEN_ACC{0..3}` + `_PROJECT_ID_ACC{N}` + `_ENVIRONMENT_ID_ACC{N}` + `_TOKEN_KIND_ACC{N}` (team/project/auto)
- `RailwayError::NotAuthorized { account }` typed error

`crates/trios-railway-mcp/src/tools.rs`:
- Every request struct gains optional `account: Option<String>`
- New `build_client_for(alias)` helper routes via `RailwayMultiClient::from_env()`
- All 4 mutation tools (`railway_service_list/deploy/redeploy/delete`) accept the new field
- Full backward compat: tools called without `account` still hit the legacy `RAILWAY_TOKEN`

`crates/trios-railway-mcp/MULTI_ACCOUNT.md` — operator README:
- 4-account env block (copy-paste-ready, with each account's project/env UUIDs)
- Tool-call JSON examples
- Docker deploy recipe
- Perplexity Custom Remote Connector setup steps
- Honest scope notes

## Tests

**115 / 115 GREEN** (was 104 → +11 multiclient).

Critical:

```
test multiclient::tests::debug_format_does_not_leak_token ... ok
test multiclient::tests::from_env_picks_up_four_accounts_when_all_set ... ok
test multiclient::tests::get_unknown_account_returns_not_authorized ... ok
test multiclient::tests::scope_all_iterates_in_acc0_acc1_acc2_acc3_order ... ok
```

## Operator next steps

1. Get personal API tokens for all four accounts at https://railway.com/account/tokens
2. Pull `ghcr.io/ghashtag/trios-railway-mcp:latest` (or rebuild from this branch)
3. Set `RAILWAY_TOKEN_ACC{0..3}` + project/env/kind blocks per `MULTI_ACCOUNT.md`
4. Deploy single MCP service (or replace existing one); healthcheck `/healthz` → 200
5. Add as Streamable HTTP custom connector in Perplexity → enable in Sources
6. Tool calls with `"account": "acc0"`/`"acc1"`/`"acc2"`/`"acc3"` route correctly

## Honest scope

- The MCP picks `RailwayMultiClient::from_env()` at every tool call. Cheap; future PR can cache once at startup.
- `Scope::All` is plumbed in `core` but not yet wired to a tool — `railway_fleet_probe` is the natural follow-up (kept out of this diff to stay reviewable).
- This PR does NOT delete the legacy single-token path. Tools without `account` still work as before.
- Token redaction enforced by `secrecy` crate + custom `Debug` impl + regression test.

## Refs

- Closes: #61, trios-mcp#2
- Tracker: #43
- Stacks on: #64 (only for branch base; logically independent)
- Race: gHashTag/trios#143

`phi^2 + phi^-2 = 3 · TRINITY · NEVER STOP`
