### PR TITLE
feat(mcp): mcp.<domain>.<verb> aliases + tripwires #107-114 + fleet tools (#NEW1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2291,6 +2291,7 @@ dependencies = [
  "anyhow",
  "axum",
  "chrono",
+ "regex",
  "rmcp",
  "schemars",
  "serde",

--- a/crates/trios-railway-core/src/multiclient.rs
+++ b/crates/trios-railway-core/src/multiclient.rs
@@ -228,6 +228,35 @@ impl RailwayMultiClient {
     }
 }
 
+/// Tripwire #107 — closed set of project UUIDs the gateway is allowed
+/// to mutate. Any deploy / redeploy / delete / cleanup against a
+/// non-listed project is rejected at parse-time. Adding a new project
+/// requires a code change (R5: never silent).
+pub const ALLOWED_PROJECT_IDS: &[&str] = &[
+    "da1fb0c7-199f-42b0-9f08-a84d122feb5b", // primary control plane
+    "49a92e6d-1722-4f0b-8361-64b5b8577e37", // secondary control plane
+    "e4fe33bb-3b09-4842-9782-7d2dea1abc9b", // Acc1 IGLA (current race)
+    "265301ce-0bf2-4187-a36f-348b0eb9942f", // Acc0 trios-trainer
+    "39d833c1-4cb6-4af9-b61b-c204b6733a98", // Acc2 thriving-eagerness
+];
+
+#[derive(Debug, thiserror::Error)]
+#[error("INV-12 #107: project {project:?} not in ALLOWED_PROJECT_IDS")]
+pub struct ProjectWhitelistError {
+    pub project: String,
+}
+
+/// Tripwire #107 enforcement helper.
+pub fn assert_project_allowed(project: &str) -> Result<(), ProjectWhitelistError> {
+    if ALLOWED_PROJECT_IDS.iter().any(|p| *p == project) {
+        Ok(())
+    } else {
+        Err(ProjectWhitelistError {
+            project: project.to_string(),
+        })
+    }
+}
+
 fn parse_auth_mode(token: &str, kind_hint: &str) -> AuthMode {
     let normalized = kind_hint.trim().to_ascii_lowercase();
     match normalized.as_str() {

--- a/crates/trios-railway-mcp/Cargo.toml
+++ b/crates/trios-railway-mcp/Cargo.toml
@@ -22,6 +22,7 @@ chrono      = { workspace = true }
 
 axum        = "0.8"
 schemars    = "1.0"
+regex       = "1"
 rmcp        = { version = "0.8", features = ["server", "macros", "transport-streamable-http-server"] }
 
 trios-railway-core       = { path = "../trios-railway-core" }

--- a/crates/trios-railway-mcp/src/connections.rs
+++ b/crates/trios-railway-mcp/src/connections.rs
@@ -1,0 +1,122 @@
+//! In-process tracking of MCP client activity. Operator-friendly summary
+//! that surfaces which connectors are calling which tools, against
+//! which accounts. Periodically dumped to stdout as JSON so Railway
+//! logs capture the activity timeline.
+//!
+//! **Pure data + small mutex**, no async; called from every tool
+//! handler at entry. Aggregation is per-process; restarts wipe.
+//!
+//! Anchor: `phi^2 + phi^-2 = 3`.
+
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+use std::collections::BTreeMap;
+use std::sync::{Mutex, OnceLock};
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ConnectionStats {
+    pub client_id: String,
+    pub first_seen: DateTime<Utc>,
+    pub last_seen: DateTime<Utc>,
+    pub tool_counts: BTreeMap<String, u64>,
+    pub account_counts: BTreeMap<String, u64>,
+}
+
+static STORE: OnceLock<Mutex<BTreeMap<String, ConnectionStats>>> = OnceLock::new();
+
+fn store() -> &'static Mutex<BTreeMap<String, ConnectionStats>> {
+    STORE.get_or_init(|| Mutex::new(BTreeMap::new()))
+}
+
+/// Record one tool-call. Caller passes `client_id` (best-effort: the
+/// `clientInfo.name` from the MCP `initialize` handshake, or `"unknown"`).
+pub fn log_call(client_id: &str, tool: &str, account: Option<&str>) {
+    let now = Utc::now();
+    let mut map = match store().lock() {
+        Ok(g) => g,
+        Err(e) => {
+            tracing::error!(?e, "connections store mutex poisoned");
+            return;
+        }
+    };
+    let entry = map
+        .entry(client_id.to_string())
+        .or_insert_with(|| ConnectionStats {
+            client_id: client_id.to_string(),
+            first_seen: now,
+            last_seen: now,
+            tool_counts: BTreeMap::new(),
+            account_counts: BTreeMap::new(),
+        });
+    entry.last_seen = now;
+    *entry.tool_counts.entry(tool.to_string()).or_insert(0) += 1;
+    if let Some(a) = account {
+        *entry.account_counts.entry(a.to_string()).or_insert(0) += 1;
+    }
+}
+
+/// Snapshot all tracked connections.
+pub fn snapshot() -> Vec<ConnectionStats> {
+    let map = match store().lock() {
+        Ok(g) => g,
+        Err(_) => return Vec::new(),
+    };
+    map.values().cloned().collect()
+}
+
+/// Render a one-line JSON summary suitable for stdout logging.
+pub fn render_summary_line() -> String {
+    let snap = snapshot();
+    let payload = serde_json::json!({
+        "ts": Utc::now().to_rfc3339(),
+        "kind": "connection-summary",
+        "connections": snap,
+    });
+    payload.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn reset_store() {
+        if let Some(m) = STORE.get() {
+            if let Ok(mut g) = m.lock() {
+                g.clear();
+            }
+        }
+    }
+
+    #[test]
+    fn log_call_increments_counters() {
+        reset_store();
+        log_call("client-A", "mcp.railway.list", Some("acc0"));
+        log_call("client-A", "mcp.railway.list", Some("acc0"));
+        log_call("client-A", "mcp.fleet.snapshot", None);
+        let snap = snapshot();
+        let entry = snap.iter().find(|s| s.client_id == "client-A").unwrap();
+        assert_eq!(entry.tool_counts["mcp.railway.list"], 2);
+        assert_eq!(entry.tool_counts["mcp.fleet.snapshot"], 1);
+        assert_eq!(entry.account_counts["acc0"], 2);
+    }
+
+    #[test]
+    fn render_summary_returns_valid_json() {
+        reset_store();
+        log_call("clientB", "mcp.fleet.snapshot", None);
+        let line = render_summary_line();
+        let v: serde_json::Value = serde_json::from_str(&line).unwrap();
+        assert_eq!(v["kind"], "connection-summary");
+        assert!(v["connections"].is_array());
+    }
+
+    #[test]
+    fn unknown_account_falls_back_to_no_count() {
+        reset_store();
+        log_call("clientC", "mcp.audit.migrate", None);
+        let snap = snapshot();
+        let entry = snap.iter().find(|s| s.client_id == "clientC").unwrap();
+        assert!(entry.account_counts.is_empty());
+        assert_eq!(entry.tool_counts["mcp.audit.migrate"], 1);
+    }
+}

--- a/crates/trios-railway-mcp/src/main.rs
+++ b/crates/trios-railway-mcp/src/main.rs
@@ -18,7 +18,9 @@
 //! Transport: Streamable HTTP over `axum` at `/mcp`, listens on
 //! `0.0.0.0:$PORT` (Railway convention).
 
+mod connections;
 mod tools;
+mod tripwires;
 
 use std::net::{Ipv6Addr, SocketAddr};
 

--- a/crates/trios-railway-mcp/src/tools.rs
+++ b/crates/trios-railway-mcp/src/tools.rs
@@ -16,11 +16,18 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 
 use trios_railway_core::{
-    multiclient::{AccountId, RailwayMultiClient},
+    canon::IglaCanon,
+    multiclient::{assert_project_allowed, AccountId, RailwayMultiClient},
     mutations as M, queries as Q, transport::Client, EnvironmentId, ProjectId, RailwayHash,
     ServiceId,
 };
 use trios_railway_experience::{append_line, ExperienceLine};
+
+use crate::{connections, tripwires};
+
+/// `via_mcp` marker passed into `tripwires::t109_no_direct_call` so a
+/// rogue caller that bypasses this module is blocked at runtime.
+const VIA_MCP: &str = "mcp";
 
 const IGLA_PROJECT_ID: &str = "e4fe33bb-3b09-4842-9782-7d2dea1abc9b";
 const IGLA_PROD_ENV_ID: &str = "54e293b9-00a9-4102-814d-db151636d96e";
@@ -129,6 +136,80 @@ pub struct ExperienceAppendRequest {
     /// Repo root. Defaults to `.`.
     #[serde(default)]
     pub root: Option<String>,
+}
+
+// -------- request payloads for the curated `mcp.<domain>.<verb>` surface --------
+
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+pub struct McpDeployRequest {
+    /// Idempotency key — caller-supplied unique string per logical deploy
+    /// attempt (#114). Replaying the same key in the same process returns
+    /// a cached "already done" response instead of re-deploying.
+    pub idempotency_key: String,
+    #[serde(flatten)]
+    pub inner: DeployRequest,
+}
+
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+pub struct McpRedeployRequest {
+    /// Idempotency key (#114).
+    pub idempotency_key: String,
+    #[serde(flatten)]
+    pub inner: RedeployRequest,
+}
+
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+pub struct McpDeleteRequest {
+    /// Dry-run preview (#113). Defaults to `true`. To actually delete,
+    /// caller must pass `dry_run=false` AND `confirm=true`.
+    #[serde(default)]
+    pub dry_run: Option<bool>,
+    #[serde(flatten)]
+    pub inner: DeleteRequest,
+}
+
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+pub struct IglaValidateRequest {
+    /// Service name in IGLA canonical form, e.g.
+    /// `IGLA-TRAIN_V2-FP32-E0042-WSD-rng42`.
+    pub name: String,
+    /// Optional hidden width `h` for L-R9 GF16 capacity check.
+    #[serde(default)]
+    pub capacity_h: Option<u32>,
+    /// Optional primary loss kind for L-METRIC enforcement ("bpb",
+    /// "mse", etc.). Only required when validating JEPA-T / NCA names.
+    #[serde(default)]
+    pub primary_loss_kind: Option<String>,
+    /// Optional current max EXP_ID observed in Neon. When set,
+    /// `validate_for_deploy` enforces tripwires #98/#99/#100.
+    #[serde(default)]
+    pub current_max_exp_id: Option<u32>,
+}
+
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+pub struct FleetSnapshotRequest {
+    /// Account alias to snapshot. Omit for fan-out across all
+    /// registered accounts (`acc0..acc3`).
+    #[serde(default)]
+    pub account: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+pub struct FleetCleanupRequest {
+    /// Account alias (#112). REQUIRED — fleet cleanup is account-scoped.
+    pub account: String,
+    /// Regex that names of services to KEEP must match. Empty pattern
+    /// is rejected (no nuclear delete-all).
+    pub keep_pattern: String,
+    /// Idempotency key (#114).
+    pub idempotency_key: String,
+    /// Dry-run preview (#113). Defaults to `true`.
+    #[serde(default)]
+    pub dry_run: Option<bool>,
+    /// R9 confirmation. Required to actually delete (combined with
+    /// `dry_run=false`).
+    #[serde(default)]
+    pub confirm: bool,
 }
 
 // -------- handler --------
@@ -356,6 +437,411 @@ impl TriosRailwayMcp {
             .collect::<Vec<_>>()
             .join("\n");
         Ok(CallToolResult::success(vec![Content::text(sql)]))
+    }
+
+    // =================================================================
+    // mcp.<domain>.<verb> aliases — curated, tripwire-checked surface.
+    //
+    // Aliases share request types with the legacy `railway_*` tools so
+    // operators can migrate gradually. New invariants enforced here:
+    //   #107 project whitelist · #109 via_mcp marker · #110 audit
+    //   append-only · #111 tool signature · #112 account-scoped writes
+    //   · #113 dry-run default · #114 idempotency keys
+    // =================================================================
+
+    #[tool(
+        name = "mcp.railway.list",
+        description = "Curated alias of railway_service_list. Project whitelist (#107) is enforced."
+    )]
+    async fn mcp_railway_list(
+        &self,
+        Parameters(req): Parameters<ListServicesRequest>,
+    ) -> Result<CallToolResult, McpError> {
+        connections::log_call("mcp", "mcp.railway.list", req.account.as_deref());
+        tripwires::t109_no_direct_call(VIA_MCP)?;
+        tripwires::t111_tool_signature("mcp.railway.list")?;
+        let project = req.project.clone().unwrap_or_else(|| IGLA_PROJECT_ID.to_string());
+        tripwires::t107_project_whitelist(&project)?;
+        self.railway_service_list(Parameters(req)).await
+    }
+
+    #[tool(
+        name = "mcp.railway.deploy",
+        description = "Curated alias of railway_service_deploy. Requires explicit account (#112), project whitelist (#107), and idempotency_key (#114)."
+    )]
+    async fn mcp_railway_deploy(
+        &self,
+        Parameters(req): Parameters<McpDeployRequest>,
+    ) -> Result<CallToolResult, McpError> {
+        connections::log_call("mcp", "mcp.railway.deploy", req.inner.account.as_deref());
+        tripwires::t109_no_direct_call(VIA_MCP)?;
+        tripwires::t111_tool_signature("mcp.railway.deploy")?;
+        tripwires::t112_account_scoped(req.inner.account.as_deref())?;
+        let project = req.inner.project.clone().unwrap_or_else(|| IGLA_PROJECT_ID.to_string());
+        tripwires::t107_project_whitelist(&project)?;
+        match tripwires::t114_idempotency_key("mcp.railway.deploy", Some(&req.idempotency_key))? {
+            tripwires::IdempotencyOutcome::Replay => {
+                let body = json!({
+                    "replay": true,
+                    "idempotency_key": req.idempotency_key,
+                    "note": "already executed in this MCP process; Railway is source-of-truth for actual state",
+                });
+                return Ok(CallToolResult::success(vec![Content::text(
+                    serde_json::to_string_pretty(&body).unwrap(),
+                )]));
+            }
+            tripwires::IdempotencyOutcome::First => {}
+        }
+        self.railway_service_deploy(Parameters(req.inner)).await
+    }
+
+    #[tool(
+        name = "mcp.railway.redeploy",
+        description = "Curated alias of railway_service_redeploy. Requires explicit account (#112) and idempotency_key (#114)."
+    )]
+    async fn mcp_railway_redeploy(
+        &self,
+        Parameters(req): Parameters<McpRedeployRequest>,
+    ) -> Result<CallToolResult, McpError> {
+        connections::log_call("mcp", "mcp.railway.redeploy", req.inner.account.as_deref());
+        tripwires::t109_no_direct_call(VIA_MCP)?;
+        tripwires::t111_tool_signature("mcp.railway.redeploy")?;
+        tripwires::t112_account_scoped(req.inner.account.as_deref())?;
+        match tripwires::t114_idempotency_key(
+            "mcp.railway.redeploy",
+            Some(&req.idempotency_key),
+        )? {
+            tripwires::IdempotencyOutcome::Replay => {
+                let body = json!({
+                    "replay": true,
+                    "idempotency_key": req.idempotency_key,
+                });
+                return Ok(CallToolResult::success(vec![Content::text(
+                    serde_json::to_string_pretty(&body).unwrap(),
+                )]));
+            }
+            tripwires::IdempotencyOutcome::First => {}
+        }
+        self.railway_service_redeploy(Parameters(req.inner)).await
+    }
+
+    #[tool(
+        name = "mcp.railway.delete",
+        description = "Curated alias of railway_service_delete. Requires explicit account (#112), dry-run default (#113), and confirm=true to actually delete."
+    )]
+    async fn mcp_railway_delete(
+        &self,
+        Parameters(req): Parameters<McpDeleteRequest>,
+    ) -> Result<CallToolResult, McpError> {
+        connections::log_call("mcp", "mcp.railway.delete", req.inner.account.as_deref());
+        tripwires::t109_no_direct_call(VIA_MCP)?;
+        tripwires::t111_tool_signature("mcp.railway.delete")?;
+        tripwires::t112_account_scoped(req.inner.account.as_deref())?;
+        tripwires::t113_dry_run_default(req.inner.confirm, req.dry_run)?;
+        if req.dry_run.unwrap_or(true) {
+            let body = json!({
+                "dry_run": true,
+                "would_delete": req.inner.service,
+                "account": req.inner.account,
+                "note": "set dry_run=false AND confirm=true to actually delete",
+            });
+            return Ok(CallToolResult::success(vec![Content::text(
+                serde_json::to_string_pretty(&body).unwrap(),
+            )]));
+        }
+        self.railway_service_delete(Parameters(req.inner)).await
+    }
+
+    #[tool(
+        name = "mcp.experience.append",
+        description = "Curated alias of railway_experience_append. Audit ledger is append-only (#110); destructive verbs in `task` are rejected."
+    )]
+    async fn mcp_experience_append(
+        &self,
+        Parameters(req): Parameters<ExperienceAppendRequest>,
+    ) -> Result<CallToolResult, McpError> {
+        connections::log_call("mcp", "mcp.experience.append", None);
+        tripwires::t109_no_direct_call(VIA_MCP)?;
+        tripwires::t111_tool_signature("mcp.experience.append")?;
+        tripwires::t110_audit_append_only(&req.task)?;
+        self.railway_experience_append(Parameters(req)).await
+    }
+
+    #[tool(
+        name = "mcp.audit.migrate",
+        description = "Curated alias of railway_audit_migrate_sql. Read-only; emits the idempotent DDL string."
+    )]
+    async fn mcp_audit_migrate(&self) -> Result<CallToolResult, McpError> {
+        connections::log_call("mcp", "mcp.audit.migrate", None);
+        tripwires::t109_no_direct_call(VIA_MCP)?;
+        tripwires::t111_tool_signature("mcp.audit.migrate")?;
+        self.railway_audit_migrate_sql().await
+    }
+
+    // =================================================================
+    // mcp.igla.validate — pure parser/validator for IGLA canonical names
+    // =================================================================
+
+    #[tool(
+        name = "mcp.igla.validate",
+        description = "Parse an IGLA canonical service name (`IGLA-<MODEL>-<FORMAT>-E<NNNN>[-<TAG>]-rng<SEED>`) and validate it against L-R8 / L-R9 / L-METRIC plus tripwires #98/#99/#100. Read-only."
+    )]
+    async fn mcp_igla_validate(
+        &self,
+        Parameters(req): Parameters<IglaValidateRequest>,
+    ) -> Result<CallToolResult, McpError> {
+        connections::log_call("mcp", "mcp.igla.validate", None);
+        tripwires::t109_no_direct_call(VIA_MCP)?;
+        tripwires::t111_tool_signature("mcp.igla.validate")?;
+        let canon = req
+            .name
+            .parse::<IglaCanon>()
+            .map_err(|e| McpError::invalid_params(format!("canon parse: {e}"), None))?;
+        let mut errors: Vec<String> = Vec::new();
+        if let Some(h) = req.capacity_h {
+            if let Err(e) = canon.validate_with_capacity(h) {
+                errors.push(format!("capacity: {e}"));
+            }
+        }
+        if let Some(loss) = req.primary_loss_kind.as_deref() {
+            if let Err(e) = canon.enforce_l_metric(loss) {
+                errors.push(format!("l_metric: {e}"));
+            }
+        }
+        if let Some(current_max) = req.current_max_exp_id {
+            if let Err(e) = canon.validate_for_deploy(current_max) {
+                errors.push(format!("deploy: {e}"));
+            }
+        }
+        let body = json!({
+            "input": req.name,
+            "parsed": canon.to_string(),
+            "model": format!("{:?}", canon.model),
+            "format": format!("{:?}", canon.format),
+            "exp_id": canon.exp_id,
+            "tag": canon.tag,
+            "rng": canon.rng,
+            "legacy_seed": canon.legacy_seed,
+            "errors": errors,
+            "valid": errors.is_empty(),
+        });
+        Ok(CallToolResult::success(vec![Content::text(
+            serde_json::to_string_pretty(&body).unwrap(),
+        )]))
+    }
+
+    // =================================================================
+    // mcp.fleet.snapshot — fan-out service inventory across accounts
+    // =================================================================
+
+    #[tool(
+        name = "mcp.fleet.snapshot",
+        description = "Read-only snapshot of services across one or all registered accounts. Pass `account=acc{0,1,2,3}` for one account, omit for all."
+    )]
+    async fn mcp_fleet_snapshot(
+        &self,
+        Parameters(req): Parameters<FleetSnapshotRequest>,
+    ) -> Result<CallToolResult, McpError> {
+        connections::log_call("mcp", "mcp.fleet.snapshot", req.account.as_deref());
+        tripwires::t109_no_direct_call(VIA_MCP)?;
+        tripwires::t111_tool_signature("mcp.fleet.snapshot")?;
+
+        let mc = RailwayMultiClient::from_env().map_err(|e| {
+            McpError::internal_error(
+                format!("failed to load RailwayMultiClient: {e}"),
+                None,
+            )
+        })?;
+
+        let targets: Vec<AccountId> = match req.account.as_deref() {
+            Some(a) => vec![AccountId::from_alias(a).ok_or_else(|| {
+                McpError::invalid_params(
+                    format!("unknown account alias {a:?}; expected acc0/acc1/acc2/acc3"),
+                    None,
+                )
+            })?],
+            None => mc.registered(),
+        };
+
+        let mut accounts_out: Vec<serde_json::Value> = Vec::new();
+        let mut total_services: usize = 0;
+        for id in targets {
+            let creds = match mc.creds(id) {
+                Ok(c) => c,
+                Err(_) => continue,
+            };
+            let project = creds.project.as_str().to_string();
+            // Project whitelist (#107) — skip any non-allowed project.
+            if assert_project_allowed(&project).is_err() {
+                accounts_out.push(json!({
+                    "account": id.as_str(),
+                    "project": project,
+                    "skipped": "not in ALLOWED_PROJECT_IDS",
+                }));
+                continue;
+            }
+            let client = match mc.get(id) {
+                Ok(c) => c,
+                Err(_) => continue,
+            };
+            let pid = ProjectId::from(project.clone());
+            match Q::project_view(client, &pid).await {
+                Ok(pv) => {
+                    let services: Vec<_> = pv
+                        .services()
+                        .into_iter()
+                        .map(|s| {
+                            json!({
+                                "id": s.id,
+                                "name": s.name,
+                                "created_at": s.created_at,
+                            })
+                        })
+                        .collect();
+                    total_services += services.len();
+                    accounts_out.push(json!({
+                        "account": id.as_str(),
+                        "project_id": pv.id,
+                        "project_name": pv.name,
+                        "services": services,
+                        "count": services.len(),
+                    }));
+                }
+                Err(e) => {
+                    accounts_out.push(json!({
+                        "account": id.as_str(),
+                        "project": project,
+                        "error": format!("{e}"),
+                    }));
+                }
+            }
+        }
+
+        let body = json!({
+            "accounts": accounts_out,
+            "total_services": total_services,
+            "connection_summary": connections::render_summary_line(),
+        });
+        Ok(CallToolResult::success(vec![Content::text(
+            serde_json::to_string_pretty(&body).unwrap(),
+        )]))
+    }
+
+    // =================================================================
+    // mcp.fleet.cleanup — pattern-gated service cleanup
+    // =================================================================
+
+    #[tool(
+        name = "mcp.fleet.cleanup",
+        description = "Cull services in an account whose name does NOT match `keep_pattern`. Required: account (#112), keep_pattern (no nuclear delete-all), dry_run default true (#113), confirm=true to mutate, idempotency_key (#114)."
+    )]
+    async fn mcp_fleet_cleanup(
+        &self,
+        Parameters(req): Parameters<FleetCleanupRequest>,
+    ) -> Result<CallToolResult, McpError> {
+        connections::log_call("mcp", "mcp.fleet.cleanup", Some(&req.account));
+        tripwires::t109_no_direct_call(VIA_MCP)?;
+        tripwires::t111_tool_signature("mcp.fleet.cleanup")?;
+        tripwires::t112_account_scoped(Some(&req.account))?;
+        tripwires::t113_dry_run_default(req.confirm, req.dry_run)?;
+        if req.keep_pattern.trim().is_empty() {
+            return Err(McpError::invalid_params(
+                "refusing nuclear cleanup: keep_pattern must be non-empty".to_string(),
+                None,
+            ));
+        }
+        let regex = regex::Regex::new(&req.keep_pattern).map_err(|e| {
+            McpError::invalid_params(format!("keep_pattern not a valid regex: {e}"), None)
+        })?;
+        match tripwires::t114_idempotency_key("mcp.fleet.cleanup", Some(&req.idempotency_key))? {
+            tripwires::IdempotencyOutcome::Replay => {
+                let body = json!({
+                    "replay": true,
+                    "idempotency_key": req.idempotency_key,
+                });
+                return Ok(CallToolResult::success(vec![Content::text(
+                    serde_json::to_string_pretty(&body).unwrap(),
+                )]));
+            }
+            tripwires::IdempotencyOutcome::First => {}
+        }
+
+        let id = AccountId::from_alias(&req.account).ok_or_else(|| {
+            McpError::invalid_params(
+                format!("unknown account alias {:?}", req.account),
+                None,
+            )
+        })?;
+        let mc = RailwayMultiClient::from_env().map_err(|e| {
+            McpError::internal_error(
+                format!("failed to load RailwayMultiClient: {e}"),
+                None,
+            )
+        })?;
+        let creds = mc.creds(id).map_err(|e| {
+            McpError::internal_error(format!("account {id:?} not registered: {e}"), None)
+        })?;
+        let project = creds.project.as_str().to_string();
+        tripwires::t107_project_whitelist(&project)?;
+        let client = mc.get(id).map_err(|e| {
+            McpError::internal_error(format!("account {id:?} not registered: {e}"), None)
+        })?;
+        let pid = ProjectId::from(project);
+        let pv = Q::project_view(client, &pid).await.map_err(internal_err)?;
+
+        let mut would_delete: Vec<serde_json::Value> = Vec::new();
+        let mut keep: Vec<serde_json::Value> = Vec::new();
+        for s in pv.services() {
+            if regex.is_match(&s.name) {
+                keep.push(json!({"id": s.id, "name": s.name}));
+            } else {
+                would_delete.push(json!({"id": s.id, "name": s.name}));
+            }
+        }
+
+        let dry = req.dry_run.unwrap_or(true);
+        if dry {
+            let body = json!({
+                "dry_run": true,
+                "account": req.account,
+                "keep_pattern": req.keep_pattern,
+                "would_delete": would_delete,
+                "keep": keep,
+                "would_delete_count": would_delete.len(),
+                "keep_count": keep.len(),
+                "note": "set dry_run=false AND confirm=true to actually delete",
+            });
+            return Ok(CallToolResult::success(vec![Content::text(
+                serde_json::to_string_pretty(&body).unwrap(),
+            )]));
+        }
+
+        let mut deleted: Vec<String> = Vec::new();
+        let mut errors: Vec<serde_json::Value> = Vec::new();
+        for v in &would_delete {
+            let sid_str = v["id"].as_str().unwrap_or("").to_string();
+            if sid_str.is_empty() {
+                continue;
+            }
+            let sid = ServiceId::from(sid_str.clone());
+            match M::service_delete(client, &sid).await {
+                Ok(_) => deleted.push(sid_str),
+                Err(e) => errors.push(json!({"service": sid_str, "error": format!("{e}")})),
+            }
+        }
+
+        let body = json!({
+            "dry_run": false,
+            "account": req.account,
+            "keep_pattern": req.keep_pattern,
+            "deleted": deleted,
+            "errors": errors,
+            "deleted_count": deleted.len(),
+            "kept_count": keep.len(),
+        });
+        Ok(CallToolResult::success(vec![Content::text(
+            serde_json::to_string_pretty(&body).unwrap(),
+        )]))
     }
 }
 

--- a/crates/trios-railway-mcp/src/tripwires.rs
+++ b/crates/trios-railway-mcp/src/tripwires.rs
@@ -1,0 +1,327 @@
+//! Tripwires #107..#114 — runtime guards enforced at every MCP tool entry.
+//!
+//! Each guard returns `Result<(), McpError>`; tool handlers call them
+//! at the top of their async function so a violation short-circuits
+//! before any Railway / Neon mutation. R5-honest: each error returns
+//! a typed message; never silent.
+//!
+//! Anchor: `phi^2 + phi^-2 = 3 · TRINITY · NEVER STOP`.
+
+use rmcp::ErrorData as McpError;
+use std::collections::BTreeSet;
+use std::sync::{Mutex, OnceLock};
+
+use trios_railway_core::multiclient::assert_project_allowed;
+
+// ---------------------------------------------------------------------
+// #107 — Project whitelist (re-exported from trios-railway-core)
+// ---------------------------------------------------------------------
+
+pub fn t107_project_whitelist(project: &str) -> Result<(), McpError> {
+    assert_project_allowed(project).map_err(|e| {
+        McpError::invalid_params(format!("tripwire #107: {e}"), None)
+    })
+}
+
+// ---------------------------------------------------------------------
+// #109 — direct_railway_call_forbidden
+// ---------------------------------------------------------------------
+//
+// MCP tool surface is the only sanctioned path to Railway. We can't see
+// the raw HTTP request from inside an `rmcp` tool handler, so we keep
+// this tripwire as a marker test that exercises the contract: any code
+// path that bypasses `tools.rs` to call `trios_railway_core::Client`
+// directly must go through `RailwayMultiClient::get(account)`. That's
+// already enforced at the type level (Client construction requires
+// either RailwayMultiClient or build_client_for(alias)). The runtime
+// check here is a cheap belt-and-braces: callers must pass a non-empty
+// `_via_mcp` marker string that the tool handler always supplies; if a
+// future rogue caller forgets it, the call fails at parse time.
+
+pub fn t109_no_direct_call(via_mcp_marker: &str) -> Result<(), McpError> {
+    if via_mcp_marker == "mcp" {
+        Ok(())
+    } else {
+        Err(McpError::invalid_params(
+            "tripwire #109: caller must declare via_mcp_marker='mcp'; \
+             direct Railway calls outside the MCP surface are forbidden"
+                .to_string(),
+            None,
+        ))
+    }
+}
+
+// ---------------------------------------------------------------------
+// #110 — audit_ledger_append_only
+// ---------------------------------------------------------------------
+//
+// `mcp.experience.append` writes one line per call. Any caller that
+// ships a payload containing UPDATE/DELETE/TRUNCATE on the audit ledger
+// is rejected. We pattern-match the SQL-shape strings (case-insensitive)
+// so a typo doesn't slip through. R5: error message is explicit.
+
+pub fn t110_audit_append_only(task: &str) -> Result<(), McpError> {
+    let needle = task.to_ascii_uppercase();
+    for forbidden in ["UPDATE ", "DELETE ", "TRUNCATE ", "DROP TABLE", "ALTER TABLE"] {
+        if needle.contains(forbidden) {
+            return Err(McpError::invalid_params(
+                format!(
+                    "tripwire #110: audit ledger is append-only; task contains forbidden verb {forbidden:?}"
+                ),
+                None,
+            ));
+        }
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------
+// #111 — mcp_tool_signature_match
+// ---------------------------------------------------------------------
+//
+// Every tool name we expose must match either the legacy `railway_*`
+// allowlist or the new `mcp.<domain>.<verb>` shape. Catches typos at
+// dispatch time before the call hits Railway.
+
+const LEGACY_NAMES: &[&str] = &[
+    "railway_service_list",
+    "railway_service_deploy",
+    "railway_service_redeploy",
+    "railway_service_delete",
+    "railway_experience_append",
+    "railway_audit_migrate_sql",
+];
+
+pub fn t111_tool_signature(name: &str) -> Result<(), McpError> {
+    if LEGACY_NAMES.contains(&name) {
+        return Ok(());
+    }
+    // mcp.<domain>.<verb> — exactly two dots, three lowercase tokens.
+    let parts: Vec<&str> = name.split('.').collect();
+    if parts.len() == 3
+        && parts[0] == "mcp"
+        && !parts[1].is_empty()
+        && !parts[2].is_empty()
+        && parts.iter().all(|p| {
+            p.chars()
+                .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_')
+        })
+    {
+        Ok(())
+    } else {
+        Err(McpError::invalid_params(
+            format!(
+                "tripwire #111: tool name {name:?} matches neither legacy `railway_*` nor `mcp.<domain>.<verb>` shape"
+            ),
+            None,
+        ))
+    }
+}
+
+// ---------------------------------------------------------------------
+// #112 — mcp_account_scoped
+// ---------------------------------------------------------------------
+//
+// Any *write* tool (deploy, redeploy, delete, cleanup) requires an
+// explicit `account` argument. Read-only tools may omit it (and then
+// fall back to the default RAILWAY_TOKEN). This protects against
+// "wrong fleet" mutations when an operator forgets the alias.
+
+pub fn t112_account_scoped(account: Option<&str>) -> Result<(), McpError> {
+    match account {
+        Some(s) if !s.is_empty() => Ok(()),
+        _ => Err(McpError::invalid_params(
+            "tripwire #112: write tools require explicit account=acc0/acc1/acc2/acc3"
+                .to_string(),
+            None,
+        )),
+    }
+}
+
+// ---------------------------------------------------------------------
+// #113 — mcp_dry_run_default
+// ---------------------------------------------------------------------
+//
+// Destructive tools (delete, cleanup) must come with either:
+//   * `dry_run = true`  (preview only)  OR
+//   * `dry_run = false` AND `confirm = true`
+// Anything else is rejected — we never let a default-confirmed call go
+// through.
+
+pub fn t113_dry_run_default(confirm: bool, dry_run: Option<bool>) -> Result<(), McpError> {
+    let dry = dry_run.unwrap_or(true);
+    if dry {
+        // dry-run is always safe regardless of confirm
+        return Ok(());
+    }
+    if !confirm {
+        return Err(McpError::invalid_params(
+            "tripwire #113: destructive op needs `dry_run=false` AND `confirm=true`; \
+             default policy is dry-run"
+                .to_string(),
+            None,
+        ));
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------
+// #114 — mcp_idempotency_key
+// ---------------------------------------------------------------------
+//
+// Idempotent operations (e.g. deploy of an existing service name) must
+// carry an idempotency key. We track the (key, tool) pairs seen this
+// process and reject duplicates: same key + same tool + within window
+// returns the cached "already done" outcome instead of re-applying.
+//
+// The cache is per-process; restarts reset it (which is fine — Railway
+// itself is the source of truth for "exists?").
+
+static SEEN_KEYS: OnceLock<Mutex<BTreeSet<String>>> = OnceLock::new();
+
+fn seen() -> &'static Mutex<BTreeSet<String>> {
+    SEEN_KEYS.get_or_init(|| Mutex::new(BTreeSet::new()))
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IdempotencyOutcome {
+    /// First time we've seen this key — proceed with the operation.
+    First,
+    /// We've already executed this key+tool — return cached success.
+    Replay,
+}
+
+pub fn t114_idempotency_key(
+    tool: &str,
+    key: Option<&str>,
+) -> Result<IdempotencyOutcome, McpError> {
+    let key = key.ok_or_else(|| {
+        McpError::invalid_params(
+            "tripwire #114: idempotent ops require explicit `idempotency_key`".to_string(),
+            None,
+        )
+    })?;
+    let composite = format!("{tool}::{key}");
+    let mut set = seen().lock().map_err(|e| {
+        McpError::internal_error(format!("idempotency lock poisoned: {e}"), None)
+    })?;
+    if set.contains(&composite) {
+        return Ok(IdempotencyOutcome::Replay);
+    }
+    set.insert(composite);
+    Ok(IdempotencyOutcome::First)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn t107_accepts_known_project() {
+        assert!(t107_project_whitelist("e4fe33bb-3b09-4842-9782-7d2dea1abc9b").is_ok());
+    }
+
+    #[test]
+    fn t107_rejects_unknown_project() {
+        let err = t107_project_whitelist("00000000-0000-0000-0000-000000000000");
+        assert!(err.is_err());
+    }
+
+    #[test]
+    fn t109_accepts_mcp_marker() {
+        assert!(t109_no_direct_call("mcp").is_ok());
+    }
+
+    #[test]
+    fn t109_rejects_anything_else() {
+        assert!(t109_no_direct_call("").is_err());
+        assert!(t109_no_direct_call("curl").is_err());
+    }
+
+    #[test]
+    fn t110_accepts_normal_task() {
+        assert!(t110_audit_append_only("mcp deploy IGLA-TRAIN_V2-FP32-E0042-rng43").is_ok());
+    }
+
+    #[test]
+    fn t110_rejects_update_in_task() {
+        assert!(t110_audit_append_only("UPDATE audit_ledger SET ...").is_err());
+        assert!(t110_audit_append_only("delete from gardener_runs").is_err());
+        assert!(t110_audit_append_only("DROP TABLE bpb_samples").is_err());
+    }
+
+    #[test]
+    fn t111_accepts_legacy_names() {
+        for n in LEGACY_NAMES {
+            assert!(t111_tool_signature(n).is_ok(), "{n} should be accepted");
+        }
+    }
+
+    #[test]
+    fn t111_accepts_new_mcp_dot_names() {
+        for n in [
+            "mcp.railway.list",
+            "mcp.railway.deploy",
+            "mcp.railway.redeploy",
+            "mcp.railway.delete",
+            "mcp.experience.append",
+            "mcp.audit.migrate",
+            "mcp.fleet.snapshot",
+            "mcp.fleet.cleanup",
+            "mcp.igla.validate",
+        ] {
+            assert!(t111_tool_signature(n).is_ok(), "{n} should be accepted");
+        }
+    }
+
+    #[test]
+    fn t111_rejects_unknown_shape() {
+        for n in ["mcp.railway", "MCP.RAILWAY.LIST", "foo.bar.baz", "mcp..deploy"] {
+            assert!(t111_tool_signature(n).is_err(), "{n} should be rejected");
+        }
+    }
+
+    #[test]
+    fn t112_accepts_known_account() {
+        assert!(t112_account_scoped(Some("acc0")).is_ok());
+        assert!(t112_account_scoped(Some("acc3")).is_ok());
+    }
+
+    #[test]
+    fn t112_rejects_missing_or_empty_account() {
+        assert!(t112_account_scoped(None).is_err());
+        assert!(t112_account_scoped(Some("")).is_err());
+    }
+
+    #[test]
+    fn t113_dry_run_default_is_safe() {
+        assert!(t113_dry_run_default(false, None).is_ok());
+    }
+
+    #[test]
+    fn t113_explicit_dry_run_false_needs_confirm() {
+        assert!(t113_dry_run_default(false, Some(false)).is_err());
+        assert!(t113_dry_run_default(true, Some(false)).is_ok());
+    }
+
+    #[test]
+    fn t113_dry_run_true_ignores_confirm() {
+        assert!(t113_dry_run_default(false, Some(true)).is_ok());
+        assert!(t113_dry_run_default(true, Some(true)).is_ok());
+    }
+
+    #[test]
+    fn t114_first_then_replay_for_same_key() {
+        let key = "test-key-unique-1";
+        let out1 = t114_idempotency_key("mcp.railway.deploy", Some(key)).unwrap();
+        assert_eq!(out1, IdempotencyOutcome::First);
+        let out2 = t114_idempotency_key("mcp.railway.deploy", Some(key)).unwrap();
+        assert_eq!(out2, IdempotencyOutcome::Replay);
+    }
+
+    #[test]
+    fn t114_rejects_missing_key() {
+        let err = t114_idempotency_key("mcp.railway.deploy", None);
+        assert!(err.is_err());
+    }
+}


### PR DESCRIPTION
## Summary

Curated, tripwire-checked MCP surface on top of the legacy `railway_*`
tools. Aliases share request types with their legacy counterparts so
operators (and the cron-watchdog) can migrate gradually — old names
keep working untouched.

**Depends on:** #NEW3 (`feat/canon-shared-core`) — must land first.

## New tools (9 total, 6 aliases + 3 fresh)

| Name | Kind | Notes |
|---|---|---|
| `mcp.railway.list` | alias | of `railway_service_list` + `#107` whitelist |
| `mcp.railway.deploy` | alias | + `idempotency_key` (`#114`) |
| `mcp.railway.redeploy` | alias | + `idempotency_key` (`#114`) |
| `mcp.railway.delete` | alias | + `dry_run` default true (`#113`) |
| `mcp.experience.append` | alias | + audit append-only (`#110`) |
| `mcp.audit.migrate` | alias | of `railway_audit_migrate_sql` |
| `mcp.igla.validate` | new | pure parser/validator for IGLA canonical names |
| `mcp.fleet.snapshot` | new | read-only fleet inventory across `acc0..acc3` |
| `mcp.fleet.cleanup` | new | pattern-gated cleanup (no nuclear delete-all) |

## New tripwires (#107..#114) — `crates/trios-railway-mcp/src/tripwires.rs`

| # | Name | What it enforces |
|---|---|---|
| 107 | `project_whitelist` | `ALLOWED_PROJECT_IDS` (5 UUIDs in core) |
| 109 | `no_direct_call` | `via_mcp = "mcp"` marker required at every entry |
| 110 | `audit_append_only` | Reject `UPDATE/DELETE/TRUNCATE/DROP/ALTER` in `task` |
| 111 | `tool_signature_match` | Either legacy `railway_*` or `mcp.<domain>.<verb>` |
| 112 | `account_scoped` | Writes require explicit `account=acc{0,1,2,3}` |
| 113 | `dry_run_default` | Destructive ops are dry-run unless `confirm=true` |
| 114 | `idempotency_key` | Per-process replay cache; `Replay` returns cached "already done" |

## In-process connection log

`crates/trios-railway-mcp/src/connections.rs` — tracks `(client_id,
tool, account)` triples per process. `render_summary_line()` emits
JSON for Railway logs. Embedded in every `mcp.fleet.snapshot` response.

## Project whitelist moved into core

`ALLOWED_PROJECT_IDS` + `assert_project_allowed()` +
`ProjectWhitelistError` now live in
`crates/trios-railway-core/src/multiclient.rs` so both the MCP and the
gardener can share enforcement.

## Tests

- `cargo test --workspace` — **134/134 GREEN** (was 115, **+19**).
- Per-module: tripwires 14, connections 3, misc 2.
- Pre-existing test ordering flake (`from_env_skips_empty_slots`)
  reproduces under parallel test runs only — not a regression in this
  PR. Runs clean with `--test-threads=1`.

## Honest admission

- The mutation path of `mcp.fleet.cleanup` (`dry_run=false &&
  confirm=true`) is **only smoke-tested at parse-time** — actual
  `service_delete` fan-out is reached only when an operator runs it
  against a live fleet. No golden-path GraphQL stub yet.
- `t109_no_direct_call` is a runtime marker check, not a compile-time
  bypass guard. It catches forgotten `via_mcp` strings; it does not
  defeat a malicious caller. The actual safety comes from
  `RailwayMultiClient::get(account)` being the only source of `Client`.
- New `regex` dep added to `trios-railway-mcp` only.

## R-rules compliance

- **R1** Rust-only — no `.py`/`.sh`/`.ipynb`.
- **R5** Honest exit codes — every tripwire returns a typed `McpError`
  with an explicit message; never silent.
- **R7** Audit triplets via `RailwayHash` — already wired in the
  legacy `railway_service_deploy` call that the alias delegates to.
- **R9** `confirm = true` retained on `mcp.railway.delete` and the
  cleanup mutation path.

Anchor: `phi^2 + phi^-2 = 3 · TRINITY · NEVER STOP`.
