### PR TITLE
ci: Dockerfile.seed-agent + GHA build workflow

### DIFF
--- a/.github/workflows/build-seed-agent-image.yml
+++ b/.github/workflows/build-seed-agent-image.yml
@@ -1,0 +1,67 @@
+name: Build & Push seed-agent image
+
+on:
+  push:
+    branches:
+      - feat/dockerfile-seed-agent
+      - feat/seed-agent
+      - main
+    paths:
+      - 'bin/seed-agent/**'
+      - 'crates/trios-railway-core/**'
+      - 'crates/trios-railway-experience/**'
+      - 'Dockerfile.seed-agent'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Image tag (default: latest)'
+        required: false
+        default: 'latest'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ghashtag/trios-seed-agent
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest
+            type=sha,prefix=sha-
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile.seed-agent
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64

--- a/Dockerfile.seed-agent
+++ b/Dockerfile.seed-agent
@@ -1,0 +1,78 @@
+# Multi-stage Dockerfile for seed-agent (Rust-only).
+# ADR-0081 pull-based trainer worker — consumes experiment_queue from
+# Neon, emits bpb_samples, self-decides at step 1000. Runs forever,
+# SIGTERM-safe (releases claim back to pending).
+#
+# Anchor: phi^2 + phi^-2 = 3 · TRINITY · SEED→NEON→GARDENER→LOOP
+#
+# Runtime needs NEON_DATABASE_URL, RAILWAY_ACC, RAILWAY_SERVICE_ID,
+# RAILWAY_SERVICE_NAME in the environment.
+
+# ---------- builder ----------
+FROM rust:1.90-slim-bookworm AS builder
+
+ENV CARGO_TERM_COLOR=always \
+    DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+        pkg-config \
+        ca-certificates \
+        build-essential \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+
+# Cargo files first for layer cache.
+COPY Cargo.toml Cargo.lock ./
+COPY crates/trios-railway-core/Cargo.toml       crates/trios-railway-core/Cargo.toml
+COPY crates/trios-railway-audit/Cargo.toml      crates/trios-railway-audit/Cargo.toml
+COPY crates/trios-railway-experience/Cargo.toml crates/trios-railway-experience/Cargo.toml
+COPY crates/trios-railway-mcp/Cargo.toml        crates/trios-railway-mcp/Cargo.toml
+COPY bin/tri-railway/Cargo.toml                 bin/tri-railway/Cargo.toml
+COPY bin/tri-gardener/Cargo.toml                bin/tri-gardener/Cargo.toml
+COPY bin/seed-agent/Cargo.toml                  bin/seed-agent/Cargo.toml
+
+# Stub sources to populate dependency cache.
+RUN mkdir -p crates/trios-railway-core/src \
+             crates/trios-railway-audit/src \
+             crates/trios-railway-experience/src \
+             crates/trios-railway-mcp/src \
+             bin/tri-railway/src \
+             bin/tri-gardener/src \
+             bin/seed-agent/src \
+ && echo 'fn main() {}'   > bin/tri-railway/src/main.rs \
+ && echo 'fn main() {}'   > bin/tri-gardener/src/main.rs \
+ && echo 'fn main() {}'   > bin/seed-agent/src/main.rs \
+ && echo 'fn main() {}'   > crates/trios-railway-mcp/src/main.rs \
+ && echo ''               > crates/trios-railway-core/src/lib.rs \
+ && echo ''               > crates/trios-railway-audit/src/lib.rs \
+ && echo ''               > crates/trios-railway-experience/src/lib.rs
+
+RUN cargo build --release --bin seed-agent --locked || true
+
+# Real sources.
+COPY crates ./crates
+COPY bin    ./bin
+
+RUN cargo build --release --bin seed-agent --locked
+
+# ---------- runtime ----------
+FROM debian:bookworm-slim AS runtime
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        libssl3 \
+ && rm -rf /var/lib/apt/lists/* \
+ && useradd -r -u 10002 -m -s /usr/sbin/nologin trios
+
+USER trios
+WORKDIR /home/trios
+
+COPY --from=builder /build/target/release/seed-agent /usr/local/bin/seed-agent
+
+ENV RUST_LOG=info
+
+# No port: seed-agent is a pull worker, not an HTTP server.
+ENTRYPOINT ["/usr/local/bin/seed-agent"]


### PR DESCRIPTION
Prerequisite for deploying ADR-0081 seed-agent to Railway. Adds Dockerfile.seed-agent (multi-stage, minimal debian-slim) and .github/workflows/build-seed-agent-image.yml publishing ghcr.io/ghashtag/trios-seed-agent:latest. No Rust code changes — only build infra.