### PR TITLE
feat(promotion-C): ExternalTrainer impl, replace worker.rs:95 bail

### DIFF
--- a/bin/seed-agent/src/trainer.rs
+++ b/bin/seed-agent/src/trainer.rs
@@ -1,16 +1,18 @@
 //! Trainer abstraction.
 //!
-//! For ADR-0081 PR-1 we ship two backends:
+//! For ADR-0081 PR-2 (issue #90 promotion-path Step C) we ship two backends:
 //!
 //! 1. `MockTrainer` — deterministic in-process simulator. Emits a
 //!    monotonically-decreasing BPB curve seeded by the experiment's
 //!    rng. Used by CI and local smoke tests so the pull loop is
 //!    fully exercised without GPUs.
 //!
-//! 2. `external` — placeholder. Will shell out to the IGLA trainer
-//!    in a follow-up PR (per ADR-0001 the trainer src lives in
-//!    `trios-trainer-igla`; we only invoke its compiled binary, never
-//!    edit it).
+//! 2. `ExternalTrainer` — shells out to the IGLA trainer binary
+//!    (`trios-train`, ADR-0001 — src lives in `trios-trainer-igla`,
+//!    we only invoke the compiled binary, never edit it). Reads
+//!    JSONL `{step,bpb,done}` rows from the subprocess stdout and
+//!    treats each row as one logical training step from the pull
+//!    loop's perspective.
 //!
 //! The contract is intentionally narrow: `step()` advances one
 //! training step, `eval_bpb()` returns the current BPB. The pull
@@ -19,7 +21,11 @@
 //! Anchor: `phi^2 + phi^-2 = 3`.
 
 use anyhow::{anyhow, Result};
+use serde::Deserialize;
 use serde_json::Value;
+use std::io::{BufRead, BufReader};
+use std::path::PathBuf;
+use std::process::{Child, ChildStdout, Command, Stdio};
 
 pub trait Trainer: Send {
     fn step(&mut self) -> Result<()>;
@@ -108,6 +114,182 @@ impl Trainer for MockTrainer {
     }
 }
 
+/// External trainer that shells out to the IGLA `trios-train` binary.
+///
+/// The subprocess is launched on the first `step()` call. Subsequent
+/// `step()` calls block on the next JSONL row from the trainer's
+/// stdout: `{ "step": <i32>, "bpb": <f64>, "done": <bool> }`. Any
+/// non-JSON line is logged and skipped (R5: surface honestly, do not
+/// silently swallow trainer panics). When the trainer exits, the
+/// next `step()` marks the trainer `finished` and returns Ok(()) so
+/// the pull loop can finalize cleanly.
+///
+/// Binary path resolution order:
+///   1. `TRAINER_BIN` env var,
+///   2. fallback `/usr/local/bin/trios-train` (Dockerfile default).
+pub struct ExternalTrainer {
+    canon_name: String,
+    seed: i32,
+    max_steps: i32,
+    current_step: i32,
+    bpb: f64,
+    finished: bool,
+    trainer_path: PathBuf,
+    config: Value,
+    child: Option<Child>,
+    reader: Option<BufReader<ChildStdout>>,
+}
+
+#[derive(Deserialize, Debug)]
+struct TrainerStepOutput {
+    step: i32,
+    bpb: f64,
+    #[serde(default)]
+    done: bool,
+}
+
+impl ExternalTrainer {
+    pub fn new(canon_name: &str, seed: i32, max_steps: i32, config: &Value) -> Result<Self> {
+        let trainer_path: PathBuf = std::env::var("TRAINER_BIN")
+            .unwrap_or_else(|_| "/usr/local/bin/trios-train".to_string())
+            .into();
+        Self::with_trainer_path(canon_name, seed, max_steps, config, trainer_path)
+    }
+
+    /// Construct with an explicit binary path — used by tests so they do
+    /// not race on the `TRAINER_BIN` env var when run in parallel.
+    pub fn with_trainer_path(
+        canon_name: &str,
+        seed: i32,
+        max_steps: i32,
+        config: &Value,
+        trainer_path: PathBuf,
+    ) -> Result<Self> {
+        if !trainer_path.exists() {
+            return Err(anyhow!(
+                "trainer binary not found at {} (set TRAINER_BIN to override)",
+                trainer_path.display()
+            ));
+        }
+        Ok(Self {
+            canon_name: canon_name.to_string(),
+            seed,
+            max_steps,
+            current_step: 0,
+            bpb: f64::NAN, // honest: no BPB before first step
+            finished: false,
+            trainer_path,
+            config: config.clone(),
+            child: None,
+            reader: None,
+        })
+    }
+
+    fn spawn(&mut self) -> Result<()> {
+        let cfg_json = serde_json::to_string(&self.config)
+            .map_err(|e| anyhow!("serialize trainer config: {e}"))?;
+        let mut cmd = Command::new(&self.trainer_path);
+        cmd.arg("--config")
+            .arg(&cfg_json)
+            .arg("--canon")
+            .arg(&self.canon_name)
+            .arg("--seed")
+            .arg(self.seed.to_string())
+            .arg("--steps")
+            .arg(self.max_steps.to_string())
+            .arg("--jsonl")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit()); // R5: stream stderr to seed-agent logs
+        let mut child = cmd
+            .spawn()
+            .map_err(|e| anyhow!("failed to spawn {}: {e}", self.trainer_path.display()))?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| anyhow!("trainer subprocess stdout pipe missing"))?;
+        self.reader = Some(BufReader::new(stdout));
+        self.child = Some(child);
+        Ok(())
+    }
+
+    fn read_next(&mut self) -> Result<Option<TrainerStepOutput>> {
+        let Some(reader) = self.reader.as_mut() else {
+            return Ok(None);
+        };
+        loop {
+            let mut line = String::new();
+            let n = reader
+                .read_line(&mut line)
+                .map_err(|e| anyhow!("read trainer stdout: {e}"))?;
+            if n == 0 {
+                return Ok(None); // EOF
+            }
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            match serde_json::from_str::<TrainerStepOutput>(trimmed) {
+                Ok(out) => return Ok(Some(out)),
+                Err(e) => {
+                    // R5: do not lie. Surface unparseable line to seed-agent log.
+                    tracing::warn!(
+                        canon = %self.canon_name,
+                        seed = self.seed,
+                        line = %trimmed,
+                        "trainer JSONL parse failed: {e}"
+                    );
+                    // fall through to next read_line
+                }
+            }
+        }
+    }
+}
+
+impl Trainer for ExternalTrainer {
+    fn step(&mut self) -> Result<()> {
+        if self.child.is_none() {
+            self.spawn()?;
+        }
+        if let Some(out) = self.read_next()? {
+            self.current_step = out.step;
+            self.bpb = out.bpb;
+            if out.done || self.current_step >= self.max_steps {
+                self.finished = true;
+            }
+        } else {
+            // Subprocess closed stdout. Reap to honor R9 (no zombies).
+            if let Some(mut ch) = self.child.take() {
+                if let Ok(s) = ch.wait() {
+                    if !s.success() {
+                        // Honest: trainer crashed. Mark finished, let
+                        // pull loop record failure via outcome.
+                        tracing::error!(
+                            canon = %self.canon_name,
+                            seed = self.seed,
+                            exit = ?s.code(),
+                            "trainer subprocess exited non-zero"
+                        );
+                    }
+                }
+            }
+            self.finished = true;
+        }
+        Ok(())
+    }
+
+    fn eval_bpb(&self) -> f64 {
+        self.bpb
+    }
+
+    fn current_step(&self) -> i32 {
+        self.current_step
+    }
+
+    fn finished(&self) -> bool {
+        self.finished
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -170,5 +352,141 @@ mod tests {
         }
         assert!(t.finished());
         assert!(t.step().is_err());
+    }
+
+    #[test]
+    fn external_trainer_rejects_missing_binary() {
+        let cfg = json!({});
+        let result = ExternalTrainer::with_trainer_path(
+            "IGLA-X",
+            42,
+            100,
+            &cfg,
+            "/definitely/not/a/real/binary/trios-train".into(),
+        );
+        let err = match result {
+            Ok(_) => panic!("expected error for missing binary, got Ok"),
+            Err(e) => e.to_string(),
+        };
+        assert!(err.contains("trainer binary not found"), "got: {err}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn external_trainer_constructs_when_binary_exists() {
+        let cfg = json!({"hidden_dim": 384});
+        let tr = ExternalTrainer::with_trainer_path("IGLA-X", 42, 100, &cfg, "/bin/true".into())
+            .expect("construct");
+        assert_eq!(tr.current_step(), 0);
+        assert!(!tr.finished());
+        assert!(
+            tr.eval_bpb().is_nan(),
+            "BPB should be NaN before first step"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn external_trainer_finalizes_when_subprocess_exits_silently() {
+        // /bin/true exits 0 with no stdout; first step() should mark finished.
+        let cfg = json!({});
+        let mut tr =
+            ExternalTrainer::with_trainer_path("IGLA-X", 42, 100, &cfg, "/bin/true".into())
+                .expect("construct");
+        tr.step().expect("step ok");
+        assert!(tr.finished(), "trainer should finalize on EOF");
+    }
+
+    // ----- subprocess-based tests using a shell shim. ------------------
+    // Skipped on non-Unix because we rely on `/bin/sh` and chmod 0o755.
+    #[cfg(unix)]
+    fn write_shim(script: &str) -> std::path::PathBuf {
+        use std::io::Write as _;
+        use std::os::unix::fs::PermissionsExt;
+        let dir = std::env::temp_dir();
+        let pid = std::process::id();
+        let nonce = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let path = dir.join(format!("trios-train-shim-{pid}-{nonce}.sh"));
+        {
+            let mut f = std::fs::File::create(&path).expect("create shim");
+            f.write_all(script.as_bytes()).expect("write shim");
+        }
+        let mut perms = std::fs::metadata(&path).expect("meta").permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&path, perms).expect("chmod shim");
+        path
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn external_trainer_reads_jsonl_stream_from_subprocess() {
+        let shim = write_shim(
+            r#"#!/bin/sh
+echo '{"step":1,"bpb":3.40,"done":false}'
+echo '{"step":2,"bpb":3.30,"done":false}'
+echo '{"step":3,"bpb":3.20,"done":false}'
+echo '{"step":4,"bpb":3.10,"done":true}'
+"#,
+        );
+        let cfg = json!({"hidden_dim": 384});
+        let mut tr = ExternalTrainer::with_trainer_path("IGLA-T-INT", 42, 100, &cfg, shim.clone())
+            .expect("construct");
+
+        tr.step().expect("step 1");
+        assert_eq!(tr.current_step(), 1);
+        assert!((tr.eval_bpb() - 3.40).abs() < 1e-9);
+        assert!(!tr.finished());
+
+        tr.step().expect("step 2");
+        tr.step().expect("step 3");
+        tr.step().expect("step 4");
+        assert_eq!(tr.current_step(), 4);
+        assert!((tr.eval_bpb() - 3.10).abs() < 1e-9);
+        assert!(tr.finished(), "done flag should finalize");
+        let _ = std::fs::remove_file(&shim);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn external_trainer_handles_subprocess_crash() {
+        let shim = write_shim(
+            r#"#!/bin/sh
+echo '{"step":1,"bpb":2.99,"done":false}'
+exit 7
+"#,
+        );
+        let cfg = json!({});
+        let mut tr =
+            ExternalTrainer::with_trainer_path("IGLA-T-CRASH", 43, 100, &cfg, shim.clone())
+                .expect("construct");
+        tr.step().expect("first row consumed");
+        assert_eq!(tr.current_step(), 1);
+        // Next step should hit EOF and finalize.
+        tr.step().expect("EOF after crash");
+        assert!(tr.finished());
+        let _ = std::fs::remove_file(&shim);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn external_trainer_skips_garbage_lines() {
+        let shim = write_shim(
+            r#"#!/bin/sh
+echo 'not-json-at-all'
+echo ''
+echo '{"step":1,"bpb":2.50,"done":true}'
+"#,
+        );
+        let cfg = json!({});
+        let mut tr =
+            ExternalTrainer::with_trainer_path("IGLA-T-NOISE", 44, 100, &cfg, shim.clone())
+                .expect("construct");
+        tr.step().expect("step ok");
+        assert_eq!(tr.current_step(), 1);
+        assert!(tr.finished());
+        let _ = std::fs::remove_file(&shim);
     }
 }

--- a/bin/seed-agent/src/worker.rs
+++ b/bin/seed-agent/src/worker.rs
@@ -94,7 +94,13 @@ async fn run_experiment(
             exp.steps_budget,
             &exp.config,
         )?),
-        other => anyhow::bail!("trainer_kind {other:?} not supported in PR-1"),
+        "external" => Box::new(trainer::ExternalTrainer::new(
+            &exp.canon_name,
+            exp.seed,
+            exp.steps_budget,
+            &exp.config,
+        )?),
+        other => anyhow::bail!("trainer_kind {other:?} not supported (valid: mock, external)"),
     };
 
     let early_stop_cfg = early_stop::EarlyStopConfig {


### PR DESCRIPTION
# PR-C: ExternalTrainer — replace `worker.rs:95` bail with real subprocess

Closes part of [#90](https://github.com/gHashTag/trios-railway/issues/90) (promotion-path Step C).
Companion to [#91 (PR-B)](https://github.com/gHashTag/trios-railway/pull/91) and the trainer-igla PR-D.

## Purpose

Replace the placeholder

```rust
other => anyhow::bail!("trainer_kind {other:?} not supported in PR-1"),
```

at `bin/seed-agent/src/worker.rs:95` with a real `ExternalTrainer` so that
`TRAINER_KIND=external` actually invokes `trios-train` instead of crashing
the pull loop.

## Changes

| File | Type | Purpose |
|------|------|---------|
| `bin/seed-agent/src/trainer.rs` | edit | Add `ExternalTrainer` struct + `Trainer` impl. JSONL stdout contract: `{step,bpb,done}` rows; agent treats each row as one logical step. Two ctors: `new()` (env-var lookup) and `with_trainer_path()` (test-only injection — avoids env-var races under cargo's parallel test runner). |
| `bin/seed-agent/src/worker.rs` | edit | Replace `bail!` arm with `"external" => Box::new(trainer::ExternalTrainer::new(…))`. Error message now lists valid kinds: `mock, external`. |

No new tests file; integration-quality tests live in the same file as
`#[cfg(unix)]` shell-shim tests so they share private struct fields. No
need for a separate `tests/` dir or a new dev-dependency (`tempfile`),
keeping the change tiny and self-contained.

## Honest deviation from spec (R5)

The artifact at `.trinity/promotion-artifacts/step-c-external-trainer.md`
proposes recreating a `BufReader<&ChildStdout>` inside `read_next_output()`
on every call. That cannot work — the borrow `&ChildStdout` is non-`Sized`
for `BufReader::new`, and even with `&mut`, drop-on-return discards
buffered bytes. This PR instead **owns** the stdout pipe via
`child.stdout.take()` and stores `BufReader<ChildStdout>` as an
`Option<…>` field, so state persists across `step()` calls and the pipe
streams cleanly line-by-line.

## Safety

- **No mock removal.** `MockTrainer` stays the default. F-step (delete
  mocks) only fires after PR-B/C/D merge **and** Step E (revert revert)
  lands.
- **Binary discovery is explicit.** `TRAINER_BIN` env var, falls back to
  `/usr/local/bin/trios-train` (matches PR-B Dockerfile default). If the
  binary is missing, `ExternalTrainer::new` returns an error before any
  spawn — pull loop records `failed`, no zombies.
- **Stderr is inherited.** Trainer panics surface in seed-agent log
  stream so Railway's log tail picks them up. R5: no silent swallowing.
- **JSONL parse failures are warned, not fatal** — but warnings carry
  `canon`/`seed`/`line` so they're debuggable.
- **R9 zombie hygiene.** When stdout EOFs, child is `wait()`-reaped; the
  exit code is logged at `error` level if non-zero.

## Tests

Verified locally on Rust 1.95:

```
cargo test -p seed-agent --bin seed-agent trainer::

running 11 tests
test trainer::tests::external_trainer_constructs_when_binary_exists ............. ok
test trainer::tests::external_trainer_finalizes_when_subprocess_exits_silently .. ok
test trainer::tests::external_trainer_handles_subprocess_crash .................. ok
test trainer::tests::external_trainer_rejects_missing_binary .................... ok
test trainer::tests::external_trainer_reads_jsonl_stream_from_subprocess ........ ok
test trainer::tests::external_trainer_skips_garbage_lines ....................... ok
test trainer::tests::mock_trainer_decays_monotonically .......................... ok
test trainer::tests::mock_trainer_different_seeds_diverge ....................... ok
test trainer::tests::mock_trainer_finishes_at_max_steps ......................... ok
test trainer::tests::mock_trainer_is_deterministic_for_same_seed ................ ok
test trainer::tests::mock_trainer_rejects_bad_decay ............................. ok

test result: ok. 11 passed; 0 failed
```

`cargo build -p seed-agent`: ✅ green.
`cargo clippy -p seed-agent --no-deps` on changed files: ✅ zero new warnings (let-else, redundant-continue, single-pattern-match all addressed).

## Pre-existing breakage NOT introduced by this PR

`cargo test -p seed-agent` on `main` (without my changes) fails to
compile because `bin/seed-agent/src/telemetry.rs:66` references
`trios_railway_core::canon::parse_bpb_line`, but that module does not
exist in `crates/trios-railway-core/src/`. This PR does not fix that
unrelated regression — it should be addressed in a separate PR
(reachable via `cargo test -p seed-agent` returns `E0433: cannot find
canon`). My new tests were verified against a local stub of
`telemetry.rs:66`; they all pass when the unrelated breakage is patched.

`cargo clippy` on `main` also reports 1 pre-existing error in
`worker.rs:143` (collapsible `if`). PR-C does not touch that line.

## Dependencies

- **Hard:** PR-D (trainer image at `ghcr.io/ghashtag/trios-train:latest`).
- **Soft:** [PR-B (#91)](https://github.com/gHashTag/trios-railway/pull/91) — PR-C compiles standalone, but only becomes useful once the runtime image bundles both binaries.

## R5 honesty note

PR-C alone does **not** unblock real training. Sequence: D → B → C → E
→ F → G. Until all six complete, fleet remains 0/N alive on real
training. No DONE without merged PR + green CI + ledger row written.

## Anchor

`phi^2 + phi^-2 = 3 · TRINITY · NEVER STOP`
