### PR TITLE
feat(promotion-B): minimal — Dockerfile + GHA for real-seed-agent (unblocks cascade)

### DIFF
--- a/.github/workflows/build-real-seed-agent.yml
+++ b/.github/workflows/build-real-seed-agent.yml
@@ -1,0 +1,77 @@
+name: Build & push real-seed-agent image to GHCR
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - "bin/seed-agent/**"
+      - "Dockerfile.real-seed-agent"
+      - ".github/workflows/build-real-seed-agent.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "bin/seed-agent/**"
+      - "Dockerfile.real-seed-agent"
+      - ".github/workflows/build-real-seed-agent.yml"
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: trios-seed-agent-real
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha,format=short
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile.real-seed-agent
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            TRAINER_IMAGE=ghcr.io/ghashtag/trios-train:latest
+
+  smoke-image:
+    runs-on: ubuntu-latest
+    needs: build-and-push
+    if: github.event_name != 'pull_request'
+    steps:
+      - name: Pull and inspect image
+        run: |
+          docker pull ghcr.io/ghashtag/trios-seed-agent-real:latest
+          docker run --rm --entrypoint /bin/sh \
+            ghcr.io/ghashtag/trios-seed-agent-real:latest \
+            -c 'ls -la /usr/local/bin/seed-agent /usr/local/bin/trios-train'

--- a/Dockerfile.real-seed-agent
+++ b/Dockerfile.real-seed-agent
@@ -1,0 +1,61 @@
+# Multi-stage Dockerfile for real-seed-agent
+# Builds seed-agent and copies trios-train binary from trainer image.
+#
+# Anchor: phi^2 + phi^-2 = 3
+# ADR-0001: trainer src lives in gHashTag/trios-trainer-igla; seed-agent only
+#           invokes its compiled binary.
+
+# -----------------------------------------------------------------------------
+# Stage 1: Trainer binary stage (image is built by Step D pipeline).
+# -----------------------------------------------------------------------------
+ARG TRAINER_IMAGE=ghcr.io/ghashtag/trios-train:latest
+FROM ${TRAINER_IMAGE} AS trainer-stage
+# Trainer binary is already at /usr/local/bin/trios-train per Step D.
+
+# -----------------------------------------------------------------------------
+# Stage 2: Build seed-agent from source.
+# -----------------------------------------------------------------------------
+FROM rust:1.91-slim AS agent-stage
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        pkg-config libssl-dev ca-certificates build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+
+# Copy entire workspace (seed-agent depends on shared crates).
+COPY . .
+
+# Build seed-agent in release mode.
+RUN cargo build --release --bin seed-agent --locked
+
+# -----------------------------------------------------------------------------
+# Stage 3: Runtime image with both binaries.
+# -----------------------------------------------------------------------------
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates curl libssl3 \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /work
+
+# Copy binaries from previous stages.
+COPY --from=trainer-stage /usr/local/bin/trios-train /usr/local/bin/trios-train
+COPY --from=agent-stage   /build/target/release/seed-agent /usr/local/bin/seed-agent
+
+RUN chmod +x /usr/local/bin/trios-train /usr/local/bin/seed-agent
+
+# Default configuration (Railway env vars override these).
+ENV TRAINER_KIND=external \
+    TRAINER_BIN=/usr/local/bin/trios-train \
+    RUST_LOG=info \
+    SEED_AGENT_POLL_INTERVAL_MS=5000 \
+    SEED_AGENT_EARLY_STOP_STEP=2000 \
+    SEED_AGENT_EARLY_STOP_BPB_CEILING=3.0
+
+# Health check: verify seed-agent process is alive.
+HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \
+    CMD pgrep -f seed-agent >/dev/null || exit 1
+
+ENTRYPOINT ["/usr/local/bin/seed-agent"]


### PR DESCRIPTION
## 🎯 Goal

Unblock the cascade by providing minimal version of #91 — adds only new files without conflicts.

## 🐛 Problem with original #91

Original PR #91 conflicts with main because:
- Branch was created from an old commit and diverged significantly
- Main has received changes to the same files (fmt, refactors)
- Manual conflict resolution required in 5+ files

## ✅ Minimal solution

This PR adds ONLY the new files needed for Step G (real fleet deploy):

- `Dockerfile.real-seed-agent` — 3-stage build with trios-train from GHCR
- `.github/workflows/build-real-seed-agent.yml` — auto-build and push

No changes to existing source files — zero conflicts.

## 📋 After merge

- GHA builds and pushes `ghcr.io/ghashtag/trios-seed-agent-real:latest`
- Railway #92 (ExternalTrainer) can be merged
- Step F (delete 66 mocks) + Step G (deploy real fleet) can proceed

Original #91 code changes (fmt, refactors) can be done in follow-ups.

Refs #90, unblocks #91, enables #92

φ² + φ⁻² = 3 · TRINITY · NEVER STOP