### PR TITLE
L-NEON-RENAME: env var rename with legacy fallback

### DIFF
--- a/.github/workflows/dr-restore.yml
+++ b/.github/workflows/dr-restore.yml
@@ -27,10 +27,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
-      RAILWAY_TOKEN:    ${{ inputs.new_token != '' && inputs.new_token || secrets.RAILWAY_TOKEN }}
-      NEON_DATABASE_URL: ${{ secrets.NEON_DATABASE_URL }}
-      GHCR_PAT:         ${{ secrets.GHCR_PAT }}
-      RUST_LOG:         info
+      RAILWAY_TOKEN:        ${{ inputs.new_token != '' && inputs.new_token || secrets.RAILWAY_TOKEN }}
+      # L-NEON-RENAME: dual-export both env names so the binary's internal
+      # fallback (RAILWAY_POSTGRES_URL primary, NEON_DATABASE_URL legacy)
+      # works in either case. Either secret may be unset on a given runner.
+      RAILWAY_POSTGRES_URL: ${{ secrets.RAILWAY_POSTGRES_URL }}
+      NEON_DATABASE_URL:    ${{ secrets.NEON_DATABASE_URL }}
+      GHCR_PAT:             ${{ secrets.GHCR_PAT }}
+      RUST_LOG:             info
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -55,9 +59,13 @@ jobs:
             ${{ inputs.champion_sha != '' && format('--champion-sha {0}', inputs.champion_sha) || '' }} \
             --confirm
 
-      - name: Apply Neon audit DDL
-        if: env.NEON_DATABASE_URL != ''
-        run: ./target/release/tri-railway audit migrate-sql | psql "$NEON_DATABASE_URL"
+      - name: Apply audit DDL
+        # L-NEON-RENAME: prefer RAILWAY_POSTGRES_URL; fall back to legacy
+        # NEON_DATABASE_URL. Run only if at least one is set.
+        if: env.RAILWAY_POSTGRES_URL != '' || env.NEON_DATABASE_URL != ''
+        run: |
+          DB_URL="${RAILWAY_POSTGRES_URL:-$NEON_DATABASE_URL}"
+          ./target/release/tri-railway audit migrate-sql | psql "$DB_URL"
 
       - name: Append L7 experience line
         run: |

--- a/.trinity/promotion-artifacts/step-g-deploy-real-fleet.md
+++ b/.trinity/promotion-artifacts/step-g-deploy-real-fleet.md
@@ -25,11 +25,18 @@ def deploy_real_fleet():
     Deploy real seed-agent workers across all accounts.
     Each worker uses external trainer (trios-train binary).
     """
-    # Get Neon database URL from gateway secrets
-    neon_url = os.environ.get("NEON_DATABASE_URL")
+    # L-NEON-RENAME: Get Postgres URL from gateway secrets. Prefer the new
+    # RAILWAY_POSTGRES_URL; fall back to the legacy NEON_DATABASE_URL so
+    # in-flight deployments keep working.
+    neon_url = (
+        os.environ.get("RAILWAY_POSTGRES_URL")
+        or os.environ.get("NEON_DATABASE_URL")
+    )
 
     if not neon_url:
-        raise ValueError("NEON_DATABASE_URL not found in environment")
+        raise ValueError(
+            "RAILWAY_POSTGRES_URL (or legacy NEON_DATABASE_URL) not found in environment"
+        )
 
     deployed = []
 
@@ -46,6 +53,9 @@ def deploy_real_fleet():
                 vars=[
                     ("TRAINER_KIND", "external"),
                     ("TRAINER_BIN", "/usr/local/bin/trios-train"),
+                    # L-NEON-RENAME: pass under both names so the trainer's
+                    # internal fallback resolves either var.
+                    ("RAILWAY_POSTGRES_URL", neon_url),
                     ("NEON_DATABASE_URL", neon_url),
                     ("RUST_LOG", "info"),
                     ("SEED_AGENT_POLL_INTERVAL_MS", "5000"),

--- a/.trinity/shiva-hub/src/index.ts
+++ b/.trinity/shiva-hub/src/index.ts
@@ -18,7 +18,12 @@ import {
 
 // Configuration from environment
 const CONFIG = {
-  neonDatabaseUrl: process.env.NEON_DATABASE_URL || process.env.POSTGRES_URL,
+  // L-NEON-RENAME: prefer RAILWAY_POSTGRES_URL; legacy NEON_DATABASE_URL and
+  // POSTGRES_URL accepted as fallback so existing deployments keep working.
+  neonDatabaseUrl:
+    process.env.RAILWAY_POSTGRES_URL ??
+    process.env.NEON_DATABASE_URL ??
+    process.env.POSTGRES_URL,
   railwayToken: process.env.RAILWAY_TOKEN,
   vibeeScript: process.env.VIBEE_SCRIPT || "/Users/playra/vibee/gleam/run_mcp.sh",
   triMcpHost: process.env.TRI_MCP_HOST || "127.0.0.1",

--- a/.trinity/shiva-hub/src/mcp-client.ts
+++ b/.trinity/shiva-hub/src/mcp-client.ts
@@ -70,8 +70,14 @@ export class McpClient extends EventEmitter {
     // NEON MCP: Use stdio with npx
     // Note: @neondatabase/mcp-server-neon is deprecated
     // Should use mcp.neon.tech instead
+    // L-NEON-RENAME: pass the URL under both names so the spawned MCP can
+    // use either (RAILWAY_POSTGRES_URL primary, legacy NEON_DATABASE_URL).
     this.process = spawn("npx", ["-y", "@neondatabase/mcp-server-neon"], {
-      env: { ...process.env, NEON_DATABASE_URL: config.neonDatabaseUrl },
+      env: {
+        ...process.env,
+        RAILWAY_POSTGRES_URL: config.neonDatabaseUrl,
+        NEON_DATABASE_URL: config.neonDatabaseUrl,
+      },
     });
 
     this.setupStdioHandlers();

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ help:
 	@echo "  smoke          - Run fast smoke test (<60s, synthetic, CPU-only)"
 	@echo "  smoke-ci       - Run smoke test with CI assertions (strict)"
 	@echo "  smoke-verbose  - Run smoke test with verbose logging"
-	@echo "  smoke-full     - Run smoke test with full validation (requires NEON_DATABASE_URL)"
+	@echo "  smoke-full     - Run smoke test with full validation (requires RAILWAY_POSTGRES_URL or legacy NEON_DATABASE_URL)"
 	@echo "  test           - Run all tests"
 	@echo "  lint           - Run clippy and rustfmt checks"
 	@echo "  clean          - Clean build artifacts"
@@ -34,10 +34,11 @@ smoke-agent:
 	@cargo run -p trios-igla-race --features smoke --bin smoke_agent -- \
 		--steps 1 --seed 42 --fail-on-error
 
-# Full smoke test with database (requires NEON_DATABASE_URL)
+# Full smoke test with database (requires RAILWAY_POSTGRES_URL or legacy
+# NEON_DATABASE_URL per L-NEON-RENAME).
 smoke-full:
-	@echo "🚀 Running full smoke test (requires NEON_DATABASE_URL)..."
-	@test -n "$(NEON_DATABASE_URL)" || (echo "ERROR: NEON_DATABASE_URL not set" && exit 1)
+	@echo "🚀 Running full smoke test (requires RAILWAY_POSTGRES_URL or legacy NEON_DATABASE_URL)..."
+	@test -n "$(RAILWAY_POSTGRES_URL)$(NEON_DATABASE_URL)" || (echo "ERROR: RAILWAY_POSTGRES_URL (or legacy NEON_DATABASE_URL) not set" && exit 1)
 	@cargo run -p trios-igla-race --bin seed_agent status
 
 # Run all tests

--- a/README.md
+++ b/README.md
@@ -61,8 +61,9 @@ cargo build --release
 # Print version
 tri-railway version
 
-# Print idempotent Neon DDL (issue #6)
-tri-railway audit migrate-sql | psql "$NEON_DATABASE_URL"
+# Print idempotent audit DDL (issue #6).
+# L-NEON-RENAME: prefer RAILWAY_POSTGRES_URL; legacy NEON_DATABASE_URL accepted.
+tri-railway audit migrate-sql | psql "${RAILWAY_POSTGRES_URL:-$NEON_DATABASE_URL}"
 
 # Append one L7 experience line
 tri-railway experience append \

--- a/bin/seed-agent/src/main.rs
+++ b/bin/seed-agent/src/main.rs
@@ -110,9 +110,7 @@ async fn main() -> Result<()> {
     let neon_url: String = match cli.neon_url.clone() {
         Some(u) if !u.is_empty() => u,
         _ => std::env::var("NEON_DATABASE_URL").map_err(|_| {
-            anyhow::anyhow!(
-                "RAILWAY_POSTGRES_URL (or legacy NEON_DATABASE_URL) not set"
-            )
+            anyhow::anyhow!("RAILWAY_POSTGRES_URL (or legacy NEON_DATABASE_URL) not set")
         })?,
     };
 

--- a/bin/seed-agent/src/main.rs
+++ b/bin/seed-agent/src/main.rs
@@ -36,9 +36,10 @@ mod worker;
 )]
 struct Cli {
     /// Railway account this worker runs in (`acc0..acc3`). Falls back
-    /// to `acc1` so an operator who set only `NEON_DATABASE_URL` (per
-    /// the #81 ONE-SHOT BRIEF) gets a sane default instead of a clap
-    /// panic on boot — root cause of B1 in the 2026-04-28 session.
+    /// to `acc1` so an operator who set only `RAILWAY_POSTGRES_URL` (or
+    /// the legacy `NEON_DATABASE_URL`, per the #81 ONE-SHOT BRIEF) gets
+    /// a sane default instead of a clap panic on boot — root cause of
+    /// B1 in the 2026-04-28 session.
     #[arg(long, env = "RAILWAY_ACC", default_value = "acc1")]
     railway_acc: String,
 
@@ -67,9 +68,14 @@ struct Cli {
     #[arg(long, default_value_t = 2.60)]
     early_stop_bpb_ceiling: f64,
 
-    /// `NEON_DATABASE_URL`. Required.
-    #[arg(long, env = "NEON_DATABASE_URL")]
-    neon_url: String,
+    /// Postgres URL for the IGLA SSOT. Reads `RAILWAY_POSTGRES_URL`
+    /// (primary, points to Railway service `phd-postgres-ssot`
+    /// `c5f37b42-832a-4acd-9749-381761c94957` as of 2026-05) with
+    /// legacy `NEON_DATABASE_URL` accepted as fallback (L-NEON-RENAME).
+    /// Required: at least one of `--neon-url`, `RAILWAY_POSTGRES_URL`,
+    /// or `NEON_DATABASE_URL` must be set.
+    #[arg(long, env = "RAILWAY_POSTGRES_URL")]
+    neon_url: Option<String>,
 
     /// Trainer kind. `external` shells out to the IGLA trainer binary
     /// (`trios-train`). `mock` runs the deterministic in-process simulator
@@ -97,6 +103,18 @@ async fn main() -> Result<()> {
         .init();
 
     let cli = Cli::parse();
+
+    // L-NEON-RENAME: resolve postgres URL with legacy fallback.
+    // Order: --neon-url CLI flag > RAILWAY_POSTGRES_URL (clap-bound above) >
+    //        legacy NEON_DATABASE_URL > error.
+    let neon_url: String = match cli.neon_url.clone() {
+        Some(u) if !u.is_empty() => u,
+        _ => std::env::var("NEON_DATABASE_URL").map_err(|_| {
+            anyhow::anyhow!(
+                "RAILWAY_POSTGRES_URL (or legacy NEON_DATABASE_URL) not set"
+            )
+        })?,
+    };
 
     let cfg = worker::WorkerConfig {
         worker_id: Uuid::new_v4(),
@@ -137,13 +155,13 @@ async fn main() -> Result<()> {
         let mut attempt = 0;
         loop {
             let tls = tokio_postgres_rustls::MakeRustlsConnect::new(tls_config.clone());
-            match tokio_postgres::connect(&cli.neon_url, tls).await {
+            match tokio_postgres::connect(&neon_url, tls).await {
                 Ok(pair) => break pair,
                 Err(e) => {
                     attempt += 1;
                     if attempt >= max_attempts {
                         anyhow::bail!(
-                            "connect to NEON_DATABASE_URL failed after {max_attempts} attempts: {e:#}"
+                            "connect to RAILWAY_POSTGRES_URL (or legacy NEON_DATABASE_URL) failed after {max_attempts} attempts: {e:#}"
                         );
                     }
                     tracing::warn!(attempt, error = %e, "neon connect failed, retrying in 2s");

--- a/bin/seed-agent/tests/smoke_test.rs
+++ b/bin/seed-agent/tests/smoke_test.rs
@@ -17,8 +17,9 @@
 /// The actual pull-to-train pipeline is tested via unit tests in
 /// `trainer::tests`, `worker::tests`, `early_stop::tests`, etc.
 #[tokio::test]
-#[ignore = "Requires NEON_DATABASE_URL and running seed-agent binary"]
+#[ignore = "Requires RAILWAY_POSTGRES_URL (or legacy NEON_DATABASE_URL) and running seed-agent binary"]
 async fn smoke_full_cycle_placeholder() {
-    // Requires NEON_DATABASE_URL and a running seed-agent binary.
-    // See unit tests in src/ for the actual test coverage.
+    // Requires RAILWAY_POSTGRES_URL (primary) or legacy NEON_DATABASE_URL
+    // (fallback), and a running seed-agent binary. See unit tests in src/
+    // for the actual test coverage.
 }

--- a/bin/tri-gardener/src/bpb_source.rs
+++ b/bin/tri-gardener/src/bpb_source.rs
@@ -77,9 +77,12 @@ pub struct NeonBpbSamples {
 
 impl NeonBpbSamples {
     pub fn from_env() -> Self {
-        Self {
-            database_url: std::env::var("NEON_DATABASE_URL").ok(),
-        }
+        // L-NEON-RENAME: prefer new RAILWAY_POSTGRES_URL; fall back to
+        // legacy NEON_DATABASE_URL so existing deployments keep working.
+        let database_url = std::env::var("RAILWAY_POSTGRES_URL")
+            .or_else(|_| std::env::var("NEON_DATABASE_URL"))
+            .ok();
+        Self { database_url }
     }
 }
 
@@ -90,7 +93,9 @@ impl BpbSource for NeonBpbSamples {
     }
     async fn fetch(&self) -> Result<Vec<BpbSample>> {
         let Some(url) = self.database_url.as_deref() else {
-            tracing::info!("NEON_DATABASE_URL not set; neon source skipped");
+            tracing::info!(
+                "RAILWAY_POSTGRES_URL (or legacy NEON_DATABASE_URL) not set; neon source skipped"
+            );
             return Ok(Vec::new());
         };
         let (client, conn) = match tokio_postgres::connect(url, tokio_postgres::NoTls).await {

--- a/bin/tri-railway/src/main.rs
+++ b/bin/tri-railway/src/main.rs
@@ -161,7 +161,8 @@ enum ServiceCmd {
 enum AuditCmd {
     /// Print idempotent DDL for the Neon schema (issue #6).
     MigrateSql,
-    /// Apply idempotent DDL directly to Neon via `NEON_DATABASE_URL`.
+    /// Apply idempotent DDL directly via `RAILWAY_POSTGRES_URL`
+    /// (legacy `NEON_DATABASE_URL` accepted as fallback per L-NEON-RENAME).
     /// Every statement is CREATE IF NOT EXISTS / CREATE OR REPLACE, so
     /// re-running is always safe.
     Migrate,
@@ -270,8 +271,15 @@ async fn main() -> Result<()> {
         Cmd::Audit {
             sub: AuditCmd::Migrate,
         } => {
-            let neon_url = std::env::var("NEON_DATABASE_URL")
-                .map_err(|_| anyhow::anyhow!("NEON_DATABASE_URL not set"))?;
+            // L-NEON-RENAME: prefer RAILWAY_POSTGRES_URL; legacy
+            // NEON_DATABASE_URL kept as fallback so existing deployments work.
+            let neon_url = std::env::var("RAILWAY_POSTGRES_URL")
+                .or_else(|_| std::env::var("NEON_DATABASE_URL"))
+                .map_err(|_| {
+                    anyhow::anyhow!(
+                        "RAILWAY_POSTGRES_URL (or legacy NEON_DATABASE_URL) not set"
+                    )
+                })?;
             let count = migrations::run_migrate(&neon_url).await?;
             println!("applied {count} DDL statements to Neon");
         }

--- a/bin/tri-railway/src/main.rs
+++ b/bin/tri-railway/src/main.rs
@@ -276,9 +276,7 @@ async fn main() -> Result<()> {
             let neon_url = std::env::var("RAILWAY_POSTGRES_URL")
                 .or_else(|_| std::env::var("NEON_DATABASE_URL"))
                 .map_err(|_| {
-                    anyhow::anyhow!(
-                        "RAILWAY_POSTGRES_URL (or legacy NEON_DATABASE_URL) not set"
-                    )
+                    anyhow::anyhow!("RAILWAY_POSTGRES_URL (or legacy NEON_DATABASE_URL) not set")
                 })?;
             let count = migrations::run_migrate(&neon_url).await?;
             println!("applied {count} DDL statements to Neon");

--- a/crates/trios-igla-race/Dockerfile.scarab
+++ b/crates/trios-igla-race/Dockerfile.scarab
@@ -2,7 +2,8 @@
 # Built from crates/trios-igla-race, single binary.
 #
 # Required:
-#   NEON_DATABASE_URL=postgres://...
+#   RAILWAY_POSTGRES_URL=postgres://...
+#   (legacy NEON_DATABASE_URL accepted as fallback per L-NEON-RENAME)
 # Optional (log label, no routing effect):
 #   SCARAB_ACCOUNT=acc0
 

--- a/crates/trios-igla-race/src/bin/debug_queue.rs
+++ b/crates/trios-igla-race/src/bin/debug_queue.rs
@@ -4,14 +4,23 @@ use trios_igla_race::pull_queue::PullQueueDb;
 
 #[derive(Parser)]
 struct Cli {
-    #[arg(long, env = "NEON_DATABASE_URL")]
-    neon_url: String,
+    /// Postgres URL. Reads `RAILWAY_POSTGRES_URL` (primary) with legacy
+    /// `NEON_DATABASE_URL` accepted as fallback (L-NEON-RENAME).
+    #[arg(long, env = "RAILWAY_POSTGRES_URL")]
+    neon_url: Option<String>,
 }
 
 #[tokio::main]
 async fn main() -> Result<()> {
     let cli = Cli::parse();
-    let db = PullQueueDb::connect(&cli.neon_url).await?;
+    // L-NEON-RENAME: legacy fallback for the postgres URL.
+    let neon_url: String = match cli.neon_url {
+        Some(u) if !u.is_empty() => u,
+        _ => std::env::var("NEON_DATABASE_URL").map_err(|_| {
+            anyhow::anyhow!("RAILWAY_POSTGRES_URL (or legacy NEON_DATABASE_URL) not set")
+        })?,
+    };
+    let db = PullQueueDb::connect(&neon_url).await?;
     let rows = db
         .raw_query(
             "SELECT id, canon_name, config_json::text, priority, seed, steps_budget, status \

--- a/crates/trios-igla-race/src/bin/reset_queue.rs
+++ b/crates/trios-igla-race/src/bin/reset_queue.rs
@@ -3,15 +3,18 @@ use trios_igla_race::pull_queue::PullQueueDb;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    // R5 / GitGuardian: connection string MUST come from CLI arg or NEON_DATABASE_URL env var.
-    // Hardcoded credentials were redacted (see GitGuardian incident 31559427); rotate the
-    // exposed Neon password before running this tool.
+    // R5 / GitGuardian: connection string MUST come from CLI arg or env.
+    // L-NEON-RENAME: prefer RAILWAY_POSTGRES_URL; legacy NEON_DATABASE_URL
+    // accepted as fallback. Hardcoded credentials were redacted (see
+    // GitGuardian incident 31559427); rotate the exposed Neon password
+    // before running this tool.
     let neon_url = std::env::args()
         .nth(1)
+        .or_else(|| std::env::var("RAILWAY_POSTGRES_URL").ok())
         .or_else(|| std::env::var("NEON_DATABASE_URL").ok())
         .ok_or_else(|| {
             anyhow::anyhow!(
-                "reset_queue: pass postgres URL as $1 or set NEON_DATABASE_URL — never hardcode"
+                "reset_queue: pass postgres URL as $1 or set RAILWAY_POSTGRES_URL (or legacy NEON_DATABASE_URL) — never hardcode"
             )
         })?;
 

--- a/crates/trios-igla-race/src/bin/scarab.rs
+++ b/crates/trios-igla-race/src/bin/scarab.rs
@@ -5,8 +5,9 @@
 //! No account affinity. No routing keys.
 //!
 //! ENV:
-//!   NEON_DATABASE_URL  — required
-//!   SCARAB_ACCOUNT     — optional log tag (no scheduling effect)
+//!   RAILWAY_POSTGRES_URL — required (legacy NEON_DATABASE_URL accepted as
+//!                           fallback per L-NEON-RENAME)
+//!   SCARAB_ACCOUNT       — optional log tag (no scheduling effect)
 
 use std::env;
 use std::process::Stdio;
@@ -74,7 +75,10 @@ async fn run_task(client: &tokio_postgres::Client, task: Task, label: &str) -> a
     let ctx = c.ctx.unwrap_or(12).to_string();
     let format = c.format.clone().unwrap_or_else(|| "fp32".into());
     let seed = c.seed.unwrap_or(1597).to_string();
-    let neon = env::var("NEON_DATABASE_URL").unwrap_or_default();
+    // L-NEON-RENAME: prefer RAILWAY_POSTGRES_URL, fall back to legacy.
+    let neon = env::var("RAILWAY_POSTGRES_URL")
+        .or_else(|_| env::var("NEON_DATABASE_URL"))
+        .unwrap_or_default();
 
     println!(
         "[{label}] START id={} name={} hidden={hidden} lr={lr} steps={steps} fmt={format} seed={seed}",
@@ -126,7 +130,10 @@ async fn run_task(client: &tokio_postgres::Client, task: Task, label: &str) -> a
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    let db_url = env::var("NEON_DATABASE_URL").expect("NEON_DATABASE_URL not set");
+    // L-NEON-RENAME: prefer RAILWAY_POSTGRES_URL, fall back to legacy.
+    let db_url = env::var("RAILWAY_POSTGRES_URL")
+        .or_else(|_| env::var("NEON_DATABASE_URL"))
+        .expect("RAILWAY_POSTGRES_URL (or legacy NEON_DATABASE_URL) not set");
     // SCARAB_ACCOUNT is a cosmetic log label only. Not a routing key.
     let label = env::var("SCARAB_ACCOUNT").unwrap_or_else(|_| "scarab".into());
     let host = env::var("HOSTNAME").unwrap_or_else(|_| "unknown".into());

--- a/crates/trios-igla-race/src/bin/seed_agent.rs
+++ b/crates/trios-igla-race/src/bin/seed_agent.rs
@@ -21,8 +21,10 @@ const DEFAULT_WORKDIR: &str = "/Users/playom/trios-trainer-igla";
     about = "ADR-001: Pull-based self-orchestrating trainer worker"
 )]
 struct Cli {
-    #[arg(long, env = "NEON_DATABASE_URL")]
-    neon_url: String,
+    /// Reads `RAILWAY_POSTGRES_URL` (primary) with legacy `NEON_DATABASE_URL`
+    /// accepted as fallback per L-NEON-RENAME.
+    #[arg(long, env = "RAILWAY_POSTGRES_URL")]
+    neon_url: Option<String>,
     #[arg(long, env = "RAILWAY_ACC", default_value = "acc0")]
     railway_acc: String,
     #[arg(
@@ -45,12 +47,20 @@ async fn main() -> Result<()> {
     let cli = Cli::parse();
     let worker_id = Uuid::new_v4();
 
+    // L-NEON-RENAME: legacy fallback for the postgres URL.
+    let neon_url: String = match cli.neon_url.clone() {
+        Some(u) if !u.is_empty() => u,
+        _ => std::env::var("NEON_DATABASE_URL").map_err(|_| {
+            anyhow::anyhow!("RAILWAY_POSTGRES_URL (or legacy NEON_DATABASE_URL) not set")
+        })?,
+    };
+
     info!(
         "seed-agent starting | worker={worker_id} | acc={}",
         cli.railway_acc
     );
 
-    let db = PullQueueDb::connect(&cli.neon_url).await?;
+    let db = PullQueueDb::connect(&neon_url).await?;
     db.health_check().await?;
     info!("Neon health check OK");
 

--- a/crates/trios-igla-race/src/bin/seed_gardener.rs
+++ b/crates/trios-igla-race/src/bin/seed_gardener.rs
@@ -4,6 +4,19 @@ use tracing::{info, warn};
 
 use trios_igla_race::pull_queue::{BpbSample, ExperimentConfig, PullQueueDb};
 
+/// L-NEON-RENAME: resolve the postgres URL from the new
+/// `RAILWAY_POSTGRES_URL` (clap-bound) with legacy `NEON_DATABASE_URL`
+/// accepted as fallback. Migration is non-breaking: deployments that
+/// only know NEON_DATABASE_URL keep working.
+fn resolve_neon_url(cli_value: Option<String>) -> Result<String> {
+    match cli_value {
+        Some(u) if !u.is_empty() => Ok(u),
+        _ => std::env::var("NEON_DATABASE_URL").map_err(|_| {
+            anyhow::anyhow!("RAILWAY_POSTGRES_URL (or legacy NEON_DATABASE_URL) not set")
+        }),
+    }
+}
+
 const GATE2_BPB: f32 = 1.85;
 const DIVERGING_GAP: f32 = 0.3;
 const MIRROR_COUNT: usize = 3;
@@ -18,12 +31,16 @@ struct Cli {
 #[derive(Subcommand)]
 enum GardenerCommand {
     Tick {
-        #[arg(long, env = "NEON_DATABASE_URL")]
-        neon_url: String,
+        /// Reads `RAILWAY_POSTGRES_URL` (primary); legacy `NEON_DATABASE_URL`
+        /// accepted as fallback per L-NEON-RENAME.
+        #[arg(long, env = "RAILWAY_POSTGRES_URL")]
+        neon_url: Option<String>,
     },
     Seed {
-        #[arg(long, env = "NEON_DATABASE_URL")]
-        neon_url: String,
+        /// Reads `RAILWAY_POSTGRES_URL` (primary); legacy `NEON_DATABASE_URL`
+        /// accepted as fallback per L-NEON-RENAME.
+        #[arg(long, env = "RAILWAY_POSTGRES_URL")]
+        neon_url: Option<String>,
         #[arg(long, default_value = "42")]
         seed: u64,
         #[arg(long, default_value = "1024")]
@@ -38,8 +55,10 @@ enum GardenerCommand {
         priority: f32,
     },
     Enqueue {
-        #[arg(long, env = "NEON_DATABASE_URL")]
-        neon_url: String,
+        /// Reads `RAILWAY_POSTGRES_URL` (primary); legacy `NEON_DATABASE_URL`
+        /// accepted as fallback per L-NEON-RENAME.
+        #[arg(long, env = "RAILWAY_POSTGRES_URL")]
+        neon_url: Option<String>,
         #[arg(long)]
         seed: u64,
         #[arg(long)]
@@ -54,8 +73,10 @@ enum GardenerCommand {
         priority: f32,
     },
     Status {
-        #[arg(long, env = "NEON_DATABASE_URL")]
-        neon_url: String,
+        /// Reads `RAILWAY_POSTGRES_URL` (primary); legacy `NEON_DATABASE_URL`
+        /// accepted as fallback per L-NEON-RENAME.
+        #[arg(long, env = "RAILWAY_POSTGRES_URL")]
+        neon_url: Option<String>,
     },
 }
 
@@ -69,7 +90,10 @@ async fn main() -> Result<()> {
     let cli = Cli::parse();
 
     match cli.command {
-        GardenerCommand::Tick { neon_url } => gardener_tick(&neon_url).await,
+        GardenerCommand::Tick { neon_url } => {
+            let url = resolve_neon_url(neon_url)?;
+            gardener_tick(&url).await
+        }
         GardenerCommand::Seed {
             neon_url,
             seed,
@@ -79,7 +103,8 @@ async fn main() -> Result<()> {
             steps,
             priority,
         } => {
-            let db = PullQueueDb::connect(&neon_url).await?;
+            let url = resolve_neon_url(neon_url)?;
+            let db = PullQueueDb::connect(&url).await?;
             let config = serde_json::json!({"seed": seed, "hidden": hidden, "ctx": ctx, "lr": lr, "steps": steps}).to_string();
             let name = format!("h{hidden}-ctx{ctx}-lr{lr:.4}-s{seed}");
             let id = db
@@ -97,7 +122,8 @@ async fn main() -> Result<()> {
             steps,
             priority,
         } => {
-            let db = PullQueueDb::connect(&neon_url).await?;
+            let url = resolve_neon_url(neon_url)?;
+            let db = PullQueueDb::connect(&url).await?;
             let config = serde_json::json!({"seed": seed, "hidden": hidden, "ctx": ctx, "lr": lr, "steps": steps}).to_string();
             let name = format!("q-h{hidden}-ctx{ctx}-lr{lr:.4}-s{seed}");
             let id = db
@@ -106,7 +132,10 @@ async fn main() -> Result<()> {
             info!("enqueued experiment id={id} name={name}");
             Ok(())
         }
-        GardenerCommand::Status { neon_url } => show_status(&neon_url).await,
+        GardenerCommand::Status { neon_url } => {
+            let url = resolve_neon_url(neon_url)?;
+            show_status(&url).await
+        }
     }
 }
 

--- a/crates/trios-railway-audit/src/event.rs
+++ b/crates/trios-railway-audit/src/event.rs
@@ -15,7 +15,8 @@
 //!         1.83,      // bpb
 //!         2000,      // step
 //!         "abc123",  // image sha (first 8 chars is fine)
-//!         &std::env::var("NEON_DATABASE_URL")?,
+//!         &std::env::var("RAILWAY_POSTGRES_URL")
+//!             .or_else(|_| std::env::var("NEON_DATABASE_URL"))?,
 //!     ).await?;
 //!     println!("inserted row_id={row_id}");
 //!     Ok(())
@@ -97,7 +98,9 @@ impl AuditArtifact {
 /// * `bpb`       – bits-per-byte from the trainer log
 /// * `step`      – training step at which BPB was measured
 /// * `image_sha` – Docker image digest / git sha (first 8 chars minimum)
-/// * `neon_url`  – full `postgres://` connection string (`NEON_DATABASE_URL`)
+/// * `neon_url`  – full `postgres://` connection string (read from
+///                 `RAILWAY_POSTGRES_URL`; legacy `NEON_DATABASE_URL`
+///                 accepted as fallback per L-NEON-RENAME)
 ///
 /// # Errors
 ///

--- a/crates/trios-railway-audit/src/event.rs
+++ b/crates/trios-railway-audit/src/event.rs
@@ -99,8 +99,8 @@ impl AuditArtifact {
 /// * `step`      – training step at which BPB was measured
 /// * `image_sha` – Docker image digest / git sha (first 8 chars minimum)
 /// * `neon_url`  – full `postgres://` connection string (read from
-///                 `RAILWAY_POSTGRES_URL`; legacy `NEON_DATABASE_URL`
-///                 accepted as fallback per L-NEON-RENAME)
+///   `RAILWAY_POSTGRES_URL`; legacy `NEON_DATABASE_URL` accepted as
+///   fallback per L-NEON-RENAME)
 ///
 /// # Errors
 ///

--- a/crates/trios-railway-mcp/src/tools.rs
+++ b/crates/trios-railway-mcp/src/tools.rs
@@ -111,8 +111,9 @@ pub struct TemplateDeployRequest {
     #[serde(default)]
     pub environment: Option<String>,
     /// Extra/override env-var pairs applied AFTER template defaults.
-    /// Only `NEON_DATABASE_URL` is required — all DSN aliases are derived
-    /// from it automatically (no more `TRIOS_NEON_DSN` / `DATABASE_URL` duplication).
+    /// Only `RAILWAY_POSTGRES_URL` (or legacy `NEON_DATABASE_URL` per
+    /// L-NEON-RENAME) is required — all DSN aliases are derived from it
+    /// automatically (no more `TRIOS_NEON_DSN` / `DATABASE_URL` duplication).
     #[serde(default)]
     pub vars_override: Vec<KeyValue>,
     /// Wave name written into the WAVE env var. Auto-generated when omitted.
@@ -378,7 +379,7 @@ impl TriosRailwayMcp {
                        'e2e-ttt-track-10min' (WIN sweep with early-stop at 1.07063). \
                        Creates one Railway service per seed, applies template defaults plus vars_override, \
                        triggers redeploys, and emits one R7 audit triplet per service. Idempotent on service name. \
-                       Only NEON_DATABASE_URL is required in vars_override — no DSN aliases needed."
+                       Only RAILWAY_POSTGRES_URL (or legacy NEON_DATABASE_URL per L-NEON-RENAME) is required in vars_override — no DSN aliases needed."
     )]
     async fn railway_template_deploy(
         &self,
@@ -506,7 +507,8 @@ impl TriosRailwayMcp {
             }
 
             // 3. assemble env: template defaults + per-seed overrides + caller overrides
-            //    DSN policy: NEON_DATABASE_URL is the single source of truth.
+            //    DSN policy: RAILWAY_POSTGRES_URL (or legacy
+            //    NEON_DATABASE_URL per L-NEON-RENAME) is the single source of truth.
             //    TRIOS_CANON_NAME (not CANON_NAME) is what train_loop.rs reads.
             let mut env: Vec<KeyValue> = template_defaults.clone();
             env.push(kv("TRIOS_SEED", &seed.to_string()));
@@ -632,7 +634,7 @@ impl ServerHandler for TriosRailwayMcp {
             instructions: Some(
                 "Public MCP server controlling the IGLA Railway project. \
                  Set RAILWAY_TOKEN before invoking deploy/redeploy/delete tools. \
-                 Only NEON_DATABASE_URL is needed — no DSN aliases required. \
+                 Only RAILWAY_POSTGRES_URL (or legacy NEON_DATABASE_URL per L-NEON-RENAME) is needed — no DSN aliases required. \
                  Anchor: phi^2 + phi^-2 = 3."
                     .to_string(),
             ),

--- a/crates/trios-railway-smoke/README.md
+++ b/crates/trios-railway-smoke/README.md
@@ -18,8 +18,11 @@ queue.push(SmokeExperiment)
 ## Usage
 
 ```bash
-# Local smoke (needs NEON_DATABASE_URL)
-export NEON_DATABASE_URL="postgresql://..."
+# Local smoke (needs RAILWAY_POSTGRES_URL or legacy NEON_DATABASE_URL).
+# L-NEON-RENAME: RAILWAY_POSTGRES_URL is the new primary; the legacy var
+# remains accepted as a fallback.
+export RAILWAY_POSTGRES_URL="postgresql://..."  # primary
+# export NEON_DATABASE_URL="postgresql://..."   # legacy fallback (optional)
 cargo test -p trios-railway-smoke
 
 # CI smoke (uses mock, no DB)

--- a/docs/DISASTER_RECOVERY.md
+++ b/docs/DISASTER_RECOVERY.md
@@ -15,7 +15,7 @@ gh secret set RAILWAY_TOKEN_ACC3 --repo gHashTag/trios-railway     # paste token
 # 2. Click the Deploy on Railway button in the README → fill 3 secrets.
 
 # 3. Migrate the audit ledger schema (idempotent).
-./target/release/tri-railway audit migrate-sql | psql "$NEON_DATABASE_URL"
+./target/release/tri-railway audit migrate-sql | psql "${RAILWAY_POSTGRES_URL:-$NEON_DATABASE_URL}"
 ```
 
 Or if `trios-railway-mcp` is reachable from your chat:
@@ -56,7 +56,7 @@ friction).
 
 The button links to a published template (manifest:
 [`railway-template.json`](../railway-template.json)). Filling in the
-required secrets (`RAILWAY_TOKEN`, `NEON_DATABASE_URL`, R2 credentials)
+required secrets (`RAILWAY_TOKEN`, `RAILWAY_POSTGRES_URL` (legacy `NEON_DATABASE_URL` honored as fallback per L-NEON-RENAME), R2 credentials)
 provisions all 6 control-plane services with `ghcr.io` image pins.
 
 ### B. CLI from a fresh shell (~3 min)
@@ -71,7 +71,8 @@ RAILWAY_TOKEN=<new-acct-token> RAILWAY_TOKEN_AUTH=team \
       --environment <NEW_ENV_UUID> \
       --name trios-mcp-public \
       --image ghcr.io/ghashtag/trios-railway-mcp:latest \
-      --var NEON_DATABASE_URL=<...> \
+      --var RAILWAY_POSTGRES_URL=<...> \
+      --var NEON_DATABASE_URL=<...>           # legacy fallback per L-NEON-RENAME (optional) \
       --var RAILWAY_TOKEN=<same-as-above> \
       --var PORT=8080
 
@@ -161,7 +162,8 @@ Stored in `gHashTag/trios-railway` Actions Secrets (`gh secret list`):
 | `RAILWAY_TOKEN_ACC3`             | Acc3 token (created during recovery)   | new account |
 | `RAILWAY_PROJECT_ACC*_*`         | Project UUIDs (auto-discovered)        | `tri-railway service list` |
 | `RAILWAY_ENV_ACC*_*`             | Environment UUIDs                      | `tri-railway service list` |
-| `NEON_DATABASE_URL`              | `postgres://...?sslmode=require`       | <https://console.neon.tech/> |
+| `RAILWAY_POSTGRES_URL`           | `postgres://...?sslmode=require` (primary, points at Railway service `phd-postgres-ssot`; L-NEON-RENAME) | Railway dashboard → service `phd-postgres-ssot` → variables |
+| `NEON_DATABASE_URL`              | legacy Postgres URL — honored as fallback if `RAILWAY_POSTGRES_URL` is unset (L-NEON-RENAME) | <https://console.neon.tech/> |
 | `TRIOS_REPO_PAT`                 | Fine-grained PAT, `issues:write` on `gHashTag/trios` | <https://github.com/settings/personal-access-tokens> |
 | `R2_ACCESS_KEY_ID`               | Cloudflare R2 access-key               | <https://dash.cloudflare.com/r2> |
 | `R2_SECRET_ACCESS_KEY`           | R2 secret-key                          | same |
@@ -191,7 +193,7 @@ Stored in `gHashTag/trios-railway` Actions Secrets (`gh secret list`):
 5. **Run the audit-ledger migration** (idempotent — safe to re-run):
 
    ```bash
-   ./target/release/tri-railway audit migrate-sql | psql "$NEON_DATABASE_URL"
+   ./target/release/tri-railway audit migrate-sql | psql "${RAILWAY_POSTGRES_URL:-$NEON_DATABASE_URL}"
    ```
 
 6. **Restore Neon ledger** (only if Neon itself was lost). Pull the
@@ -200,7 +202,7 @@ Stored in `gHashTag/trios-railway` Actions Secrets (`gh secret list`):
    ```bash
    aws s3 cp s3://igla-ledger-backups/igla/audit-ledger/<latest>.sql.gz . \
        --endpoint-url "$R2_ENDPOINT"
-   gunzip -c <latest>.sql.gz | psql "$NEON_DATABASE_URL"
+   gunzip -c <latest>.sql.gz | psql "${RAILWAY_POSTGRES_URL:-$NEON_DATABASE_URL}"
    ```
 
 7. **Update MCP config.** Point the `trios-perplexity` MCP servers at

--- a/docs/DR.md
+++ b/docs/DR.md
@@ -46,7 +46,7 @@ Total wall-time on a warm GHCR cache: **< 5 min for 16 services**.
 - [x] `restore-fleet.json` committed in `gHashTag/trios-railway`.
 - [x] `template.json` for the MCP server (1-click GHCR redeploy).
 - [x] `Dockerfile.mcp` already in repo (verified).
-- [x] GitHub Secrets set: `RAILWAY_TOKEN`, `NEON_DATABASE_URL`, `GHCR_PAT`.
+- [x] GitHub Secrets set: `RAILWAY_TOKEN`, `RAILWAY_POSTGRES_URL` (legacy `NEON_DATABASE_URL` honored as fallback per L-NEON-RENAME), `GHCR_PAT`.
 - [x] GHCR image pushed every commit on `main` (via `docker-mcp.yml` for MCP, plus a new `docker-trainer.yml` for trainer).
 - [x] Neon DDL applied; weekly `pg_dump` → S3/B2 backup.
 - [x] Embargo + ledger files mirrored to a 2nd remote (e.g. Codeberg or GitLab) — git push insurance.
@@ -121,7 +121,7 @@ Commit this file → next restore is even cheaper (no projectCreate needed if UU
 After `restore` exits 0:
 
 - `tri-railway service list` shows all 16 names.
-- `psql "$NEON_DATABASE_URL" -c 'select count(*) from igla_race_trials'` returns the pre-ban row count (Neon survived).
+- `psql "${RAILWAY_POSTGRES_URL:-$NEON_DATABASE_URL}" -c 'select count(*) from igla_race_trials'` returns the pre-ban row count (Postgres SoT survived; L-NEON-RENAME prefers the Railway var, legacy honored as fallback).
 - `trios-igla check <champion_sha>` returns OK (embargo intact).
 - `.trinity/experience/<today>.trinity` has the new RAIL=restore line.
 - `cargo test --workspace` GREEN.

--- a/docs/FLEET_OPERATIONS.md
+++ b/docs/FLEET_OPERATIONS.md
@@ -38,7 +38,7 @@
 
 ```bash
 source .env
-psql "$NEON_DATABASE_URL" -c "
+psql "${RAILWAY_POSTGRES_URL:-$NEON_DATABASE_URL}" -c "
 SELECT status, account, COUNT(*) 
 FROM experiment_queue 
 GROUP BY status, account 
@@ -49,7 +49,7 @@ ORDER BY status, account;
 ### Enqueue an experiment
 
 ```bash
-psql "$NEON_DATABASE_URL" -c "
+psql "${RAILWAY_POSTGRES_URL:-$NEON_DATABASE_URL}" -c "
 INSERT INTO experiment_queue (canon_name, config_json, priority, seed, steps_budget, account, status)
 VALUES (
   'IGLA-TRAIN_V2-GF16-E0800-H828-C12-LR0004-rng1597',
@@ -62,7 +62,7 @@ VALUES (
 ### Check worker status
 
 ```bash
-psql "$NEON_DATABASE_URL" -c "
+psql "${RAILWAY_POSTGRES_URL:-$NEON_DATABASE_URL}" -c "
 SELECT account, worker_id, 
        COUNT(*) FILTER (WHERE heartbeat > NOW() - INTERVAL '5 minutes') AS alive,
        COUNT(*) FILTER (WHERE heartbeat BETWEEN NOW() - INTERVAL '30 minutes' AND NOW() - INTERVAL '5 minutes') AS stale,
@@ -84,7 +84,8 @@ railway_service_deploy(
   environment: "<env_id>",
   image: "ghcr.io/ghashtag/trios-seed-agent-real:latest",
   vars: [
-    {key: "NEON_DATABASE_URL", value: "<neon_url>"},
+    {key: "RAILWAY_POSTGRES_URL", value: "<postgres_url>"},   // primary; L-NEON-RENAME
+    {key: "NEON_DATABASE_URL", value: "<postgres_url>"},      // legacy fallback (optional)
     {key: "RAILWAY_ACC", value: "acc{N}"},
     {key: "TRAINER_KIND", value: "external"},
     {key: "RAILWAY_SERVICE_NAME", value: "trios-train-v2-acc{N}-s1597"}
@@ -124,7 +125,8 @@ curl -s -X POST https://backboard.railway.app/graphql/v2 \
 
 # Step 3: Set env vars
 for KV in \
-  "NEON_DATABASE_URL=$NEON_DATABASE_URL" \
+  "RAILWAY_POSTGRES_URL=${RAILWAY_POSTGRES_URL:-$NEON_DATABASE_URL}" \
+  "NEON_DATABASE_URL=${RAILWAY_POSTGRES_URL:-$NEON_DATABASE_URL}" \
   "RAILWAY_ACC=$ACC" \
   "TRAINER_KIND=external" \
   "RAILWAY_SERVICE_NAME=$SVC_NAME"; do
@@ -148,7 +150,7 @@ echo "Deployed $SVC_NAME → $SVC_ID"
 ### Check experiment results
 
 ```bash
-psql "$NEON_DATABASE_URL" -c "
+psql "${RAILWAY_POSTGRES_URL:-$NEON_DATABASE_URL}" -c "
 SELECT id, canon_name, status, final_bpb, final_step, account
 FROM experiment_queue
 WHERE status IN ('done', 'failed')
@@ -160,7 +162,7 @@ LIMIT 20;
 ### View BPB samples for an experiment
 
 ```bash
-psql "$NEON_DATABASE_URL" -c "
+psql "${RAILWAY_POSTGRES_URL:-$NEON_DATABASE_URL}" -c "
 SELECT step, bpb 
 FROM bpb_samples 
 WHERE canon_name = 'IGLA-TRAIN_V2-GF16-E0800-H828-C12-LR0004-rng1597'
@@ -200,7 +202,7 @@ Only these seeds are allowed in the experiment queue:
 
 ### Worker not registering
 - Check Railway deployment logs for `ENETUNREACH` → Neon connection retry handles this
-- Check `channel_binding=require` is NOT in `NEON_DATABASE_URL`
+- Check `channel_binding=require` is NOT in `RAILWAY_POSTGRES_URL` (or legacy `NEON_DATABASE_URL` per L-NEON-RENAME)
 - Verify `RAILWAY_ACC` matches an account in the `workers` table
 
 ### step=0, bpb=NaN

--- a/docs/GARDENER_ONESHOT.md
+++ b/docs/GARDENER_ONESHOT.md
@@ -8,7 +8,7 @@
 ```bash
 cd ~/trios-railway && source .env
 
-psql "$NEON_DATABASE_URL" -c "
+psql "${RAILWAY_POSTGRES_URL:-$NEON_DATABASE_URL}" -c "
 SELECT railway_acc, railway_svc_name,
        CASE WHEN last_heartbeat > NOW() - INTERVAL '5 minutes' THEN '✅ ALIVE'
             WHEN last_heartbeat > NOW() - INTERVAL '30 minutes' THEN '⚠️ STALE'
@@ -27,7 +27,7 @@ ORDER BY railway_acc;
 ## 2. Проверить очередь экспериментов
 
 ```bash
-psql "$NEON_DATABASE_URL" -c "
+psql "${RAILWAY_POSTGRES_URL:-$NEON_DATABASE_URL}" -c "
 SELECT status, COUNT(*) FROM experiment_queue GROUP BY status ORDER BY status;
 "
 ```
@@ -41,7 +41,7 @@ SELECT status, COUNT(*) FROM experiment_queue GROUP BY status ORDER BY status;
 ## 3. Добавить эксперимент (одна команда)
 
 ```bash
-psql "$NEON_DATABASE_URL" -c "
+psql "${RAILWAY_POSTGRES_URL:-$NEON_DATABASE_URL}" -c "
 INSERT INTO experiment_queue (canon_name, config_json, priority, seed, steps_budget, account, status)
 VALUES (
   'ИМЯ-ЭКСПЕРИМЕНТА',
@@ -66,7 +66,7 @@ VALUES (
 
 ```bash
 # Последние 20 завершённых экспериментов
-psql "$NEON_DATABASE_URL" -c "
+psql "${RAILWAY_POSTGRES_URL:-$NEON_DATABASE_URL}" -c "
 SELECT id, canon_name, account,
        ROUND(final_bpb::numeric, 4) AS bpb,
        final_step AS steps,
@@ -77,7 +77,7 @@ ORDER BY id DESC LIMIT 20;
 "
 
 # Лучшие результаты (сортировка по BPB — чем меньше тем лучше)
-psql "$NEON_DATABASE_URL" -c "
+psql "${RAILWAY_POSTGRES_URL:-$NEON_DATABASE_URL}" -c "
 SELECT canon_name, account,
        ROUND(final_bpb::numeric, 4) AS bpb,
        final_step AS steps
@@ -112,7 +112,7 @@ curl -s -X POST https://backboard.railway.app/graphql/v2 \
 
 ```bash
 # Посмотреть причину
-psql "$NEON_DATABASE_URL" -c "
+psql "${RAILWAY_POSTGRES_URL:-$NEON_DATABASE_URL}" -c "
 SELECT id, canon_name, status, failed_reason
 FROM experiment_queue
 WHERE status = 'failed'
@@ -152,11 +152,11 @@ ORDER BY id DESC LIMIT 5;
 # Полный статус за одну команду:
 cd ~/trios-railway && source .env && \
 echo "=== WORKERS ===" && \
-psql "$NEON_DATABASE_URL" -c "SELECT railway_acc, railway_svc_name, CASE WHEN last_heartbeat > NOW() - INTERVAL '5 minutes' THEN '✅' ELSE '❌' END AS st FROM workers ORDER BY railway_acc;" && \
+psql "${RAILWAY_POSTGRES_URL:-$NEON_DATABASE_URL}" -c "SELECT railway_acc, railway_svc_name, CASE WHEN last_heartbeat > NOW() - INTERVAL '5 minutes' THEN '✅' ELSE '❌' END AS st FROM workers ORDER BY railway_acc;" && \
 echo "=== QUEUE ===" && \
-psql "$NEON_DATABASE_URL" -c "SELECT status, COUNT(*) FROM experiment_queue GROUP BY status ORDER BY status;" && \
+psql "${RAILWAY_POSTGRES_URL:-$NEON_DATABASE_URL}" -c "SELECT status, COUNT(*) FROM experiment_queue GROUP BY status ORDER BY status;" && \
 echo "=== LAST RESULTS ===" && \
-psql "$NEON_DATABASE_URL" -c "SELECT id, LEFT(canon_name,40) AS name, account, ROUND(final_bpb::numeric,4) AS bpb, final_step, status FROM experiment_queue WHERE status IN ('done','failed') ORDER BY id DESC LIMIT 10;"
+psql "${RAILWAY_POSTGRES_URL:-$NEON_DATABASE_URL}" -c "SELECT id, LEFT(canon_name,40) AS name, account, ROUND(final_bpb::numeric,4) AS bpb, final_step, status FROM experiment_queue WHERE status IN ('done','failed') ORDER BY id DESC LIMIT 10;"
 ```
 
 ---

--- a/docs/IMPROVEMENT_PLAN.md
+++ b/docs/IMPROVEMENT_PLAN.md
@@ -182,7 +182,7 @@ async fn experiment_queue_update(
 **Effort**: 1 hour
 
 ### 2.3 `service_variable_upsert` — Set env vars on existing service
-**Impact**: 🔴 P0 — currently done manually via curl; needed for NEON_DATABASE_URL injection on new services
+**Impact**: 🔴 P0 — currently done manually via curl; needed for `RAILWAY_POSTGRES_URL` (and legacy `NEON_DATABASE_URL` fallback per L-NEON-RENAME) injection on new services
 
 ```rust
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
@@ -221,7 +221,7 @@ pub struct BatchDeployRequest {
     pub services: Vec<BatchDeployService>,
 }
 
-#[tool(description = "Create and deploy multiple services in one call. Each service gets NEON_DATABASE_URL auto-injected.")]
+#[tool(description = "Create and deploy multiple services in one call. Each service gets RAILWAY_POSTGRES_URL (and legacy NEON_DATABASE_URL per L-NEON-RENAME) auto-injected.")]
 async fn service_batch_deploy(
     &self,
     Parameters(req): Parameters<BatchDeployRequest>,

--- a/docs/RESTORE_CLI_SPEC.md
+++ b/docs/RESTORE_CLI_SPEC.md
@@ -57,10 +57,13 @@ fn restore(args: RestoreArgs) -> Result<()> {
         tracing::info!(service=%svc.name, "restored");
     }
 
-    // 3. Neon DDL (idempotent)
-    if let Ok(neon_url) = env::var("NEON_DATABASE_URL") {
+    // 3. Audit DDL (idempotent). L-NEON-RENAME: prefer the Railway var,
+    //    fall back to the legacy NEON_DATABASE_URL.
+    if let Ok(db_url) = env::var("RAILWAY_POSTGRES_URL")
+        .or_else(|_| env::var("NEON_DATABASE_URL"))
+    {
         let ddl = audit::migrate_sql();
-        psql::run(&neon_url, &ddl)?;
+        psql::run(&db_url, &ddl)?;
     }
 
     // 4. L7 experience seal

--- a/migrations/0001_railway_audit.sql
+++ b/migrations/0001_railway_audit.sql
@@ -1,7 +1,7 @@
 -- 0001: Railway audit base tables + drift view.
 -- All statements are idempotent (IF NOT EXISTS / OR REPLACE).
--- Apply via: psql $NEON_DATABASE_URL -f migrations/0001_railway_audit.sql
---            or: tri-railway audit migrate-sql | psql $NEON_DATABASE_URL
+-- Apply via: psql "${RAILWAY_POSTGRES_URL:-$NEON_DATABASE_URL}" -f migrations/0001_railway_audit.sql
+--            or: tri-railway audit migrate-sql | psql "${RAILWAY_POSTGRES_URL:-$NEON_DATABASE_URL}"
 --            or: tri-railway audit migrate
 
 CREATE TABLE IF NOT EXISTS railway_projects (

--- a/migrations/0002_experiment_queue.sql
+++ b/migrations/0002_experiment_queue.sql
@@ -6,8 +6,8 @@
 -- step 1000.
 --
 -- All statements are idempotent (IF NOT EXISTS / OR REPLACE).
--- Apply via: psql $NEON_DATABASE_URL -f migrations/0002_experiment_queue.sql
---            or: tri-railway audit migrate-sql | psql $NEON_DATABASE_URL
+-- Apply via: psql "${RAILWAY_POSTGRES_URL:-$NEON_DATABASE_URL}" -f migrations/0002_experiment_queue.sql
+--            or: tri-railway audit migrate-sql | psql "${RAILWAY_POSTGRES_URL:-$NEON_DATABASE_URL}"
 --            or: tri-railway audit migrate
 
 -- Status enum: pending | claimed | running | pruned | done | failed

--- a/railway-template.json
+++ b/railway-template.json
@@ -2,7 +2,7 @@
   "$schema": "https://railway.com/railway.schema.json",
   "_comment": "IGLA fleet disaster-recovery template. Anchor: phi^2 + phi^-2 = 3. Maintained by scripts/snapshot-fleet.sh and disaster-recovery/fleet-snapshot.json. After publishing on Railway template marketplace, the operator gets a single Deploy on Railway button at https://railway.com/deploy/igla-fleet.",
   "name": "IGLA Fleet — DR template",
-  "description": "One-click disaster recovery for the IGLA RACE training fleet (3-seed champion + audit MCP + watchdog). Deploys 6 services pinned to a known-good GHCR image SHA, all environment variables placeholder-substituted at deploy time. After the dashboard creates the project, run `tri-railway audit migrate-sql | psql $NEON_DATABASE_URL` once to seed the audit ledger. Source: https://github.com/gHashTag/trios-railway",
+  "description": "One-click disaster recovery for the IGLA RACE training fleet (3-seed champion + audit MCP + watchdog). Deploys 6 services pinned to a known-good GHCR image SHA, all environment variables placeholder-substituted at deploy time. After the dashboard creates the project, run `tri-railway audit migrate-sql | psql \"${RAILWAY_POSTGRES_URL:-$NEON_DATABASE_URL}\"` once to seed the audit ledger (RAILWAY_POSTGRES_URL primary, legacy NEON_DATABASE_URL accepted as fallback per L-NEON-RENAME). Source: https://github.com/gHashTag/trios-railway",
 
   "services": [
     {
@@ -20,7 +20,8 @@
       "variables": {
         "RAILWAY_TOKEN":          { "description": "Personal API token for this account, from https://railway.com/account/tokens",                              "isOptional": false },
         "RAILWAY_TOKEN_AUTH":     { "description": "Auth mode: 'team' (Bearer, default for personal API tokens) or 'project' (Project-Access-Token)",          "default": "team" },
-        "NEON_DATABASE_URL":      { "description": "Postgres URL with sslmode=require for the IGLA audit ledger.",                                              "isOptional": false },
+        "RAILWAY_POSTGRES_URL":   { "description": "Postgres URL with sslmode=require for the IGLA audit ledger (primary; L-NEON-RENAME).",                       "isOptional": true },
+        "NEON_DATABASE_URL":      { "description": "Legacy Postgres URL — fallback if RAILWAY_POSTGRES_URL is unset (L-NEON-RENAME).",                            "isOptional": true },
         "RUST_LOG":               { "description": "tracing-subscriber filter.",                                                                                 "default": "info" },
         "PORT":                   { "description": "HTTP port (Railway convention).",                                                                            "default": "8080" }
       }
@@ -40,7 +41,8 @@
         "TRIOS_LANE":             { "default": "A-champion-fineweb" },
         "L_R8_SYNTHETIC_FALLBACK":{ "default": "FORBID" },
         "RUST_LOG":               { "default": "info" },
-        "NEON_DATABASE_URL":      { "description": "Same Neon URL as the MCP service. The trainer writes one row per ASHA rung.", "isOptional": false }
+        "RAILWAY_POSTGRES_URL":   { "description": "Postgres URL (primary; L-NEON-RENAME). Trainer writes one row per ASHA rung.", "isOptional": true },
+        "NEON_DATABASE_URL":      { "description": "Legacy Postgres URL — fallback if RAILWAY_POSTGRES_URL is unset (L-NEON-RENAME).", "isOptional": true }
       }
     },
     {
@@ -58,7 +60,8 @@
         "TRIOS_LANE":             { "default": "A-champion-fineweb" },
         "L_R8_SYNTHETIC_FALLBACK":{ "default": "FORBID" },
         "RUST_LOG":               { "default": "info" },
-        "NEON_DATABASE_URL":      { "isOptional": false }
+        "RAILWAY_POSTGRES_URL":   { "description": "Postgres URL (primary; L-NEON-RENAME).",                                                                "isOptional": true },
+        "NEON_DATABASE_URL":      { "description": "Legacy Postgres URL — fallback if RAILWAY_POSTGRES_URL is unset (L-NEON-RENAME).",                       "isOptional": true }
       }
     },
     {
@@ -76,7 +79,8 @@
         "TRIOS_LANE":             { "default": "A-champion-fineweb" },
         "L_R8_SYNTHETIC_FALLBACK":{ "default": "FORBID" },
         "RUST_LOG":               { "default": "info" },
-        "NEON_DATABASE_URL":      { "isOptional": false }
+        "RAILWAY_POSTGRES_URL":   { "description": "Postgres URL (primary; L-NEON-RENAME).",                                                                "isOptional": true },
+        "NEON_DATABASE_URL":      { "description": "Legacy Postgres URL — fallback if RAILWAY_POSTGRES_URL is unset (L-NEON-RENAME).",                       "isOptional": true }
       }
     },
     {
@@ -85,9 +89,10 @@
       "source": { "image": "ghcr.io/ghashtag/trios-dwagent:latest" },
       "deploy":  { "restartPolicyType": "ON_FAILURE", "numReplicas": 1 },
       "variables": {
-        "RAILWAY_TOKEN":      { "isOptional": false },
-        "NEON_DATABASE_URL":  { "isOptional": false },
-        "RUST_LOG":           { "default": "info" }
+        "RAILWAY_TOKEN":         { "isOptional": false },
+        "RAILWAY_POSTGRES_URL":  { "description": "Postgres URL (primary; L-NEON-RENAME).",                                                              "isOptional": true },
+        "NEON_DATABASE_URL":     { "description": "Legacy Postgres URL — fallback if RAILWAY_POSTGRES_URL is unset (L-NEON-RENAME).",                     "isOptional": true },
+        "RUST_LOG":              { "default": "info" }
       }
     },
     {
@@ -103,7 +108,7 @@
       "variables": {
         "SCHEDULE":              { "default": "@hourly" },
         "BACKUP_KEEP_DAYS":      { "default": "14" },
-        "POSTGRES_HOST":         { "description": "Hostname from NEON_DATABASE_URL (no protocol).",       "isOptional": false },
+        "POSTGRES_HOST":         { "description": "Hostname from RAILWAY_POSTGRES_URL (or legacy NEON_DATABASE_URL — L-NEON-RENAME), no protocol.",       "isOptional": false },
         "POSTGRES_DATABASE":     { "description": "Database name (usually 'neondb').",                    "isOptional": false },
         "POSTGRES_USER":         { "isOptional": false },
         "POSTGRES_PASSWORD":     { "isOptional": false },

--- a/restore-fleet.json
+++ b/restore-fleet.json
@@ -20,6 +20,7 @@
     { "key": "TRIOS_STEPS",             "value": "60000" },
     { "key": "TRIOS_ATTN_LAYERS",       "value": "2" },
     { "key": "L_R8_SYNTHETIC_FALLBACK", "value": "FORBID" },
+    { "key": "RAILWAY_POSTGRES_URL",    "value": "${secret:RAILWAY_POSTGRES_URL}" },
     { "key": "NEON_DATABASE_URL",       "value": "${secret:NEON_DATABASE_URL}" }
   ],
 

--- a/schemas/restore-fleet.schema.json
+++ b/schemas/restore-fleet.schema.json
@@ -77,7 +77,7 @@
       "additionalProperties": false,
       "properties": {
         "neon_ddl": {
-          "description": "Shell command piped into psql against $NEON_DATABASE_URL. Recommended: `tri-railway audit migrate-sql`.",
+          "description": "Shell command piped into psql against ${RAILWAY_POSTGRES_URL:-$NEON_DATABASE_URL} (L-NEON-RENAME: prefer new var, fall back to legacy). Recommended: `tri-railway audit migrate-sql`.",
           "type": "string"
         },
         "embargo_check": {

--- a/template.json
+++ b/template.json
@@ -10,8 +10,9 @@
     "numReplicas": 1
   },
   "envVars": {
-    "RAILWAY_TOKEN":      { "description": "Write-capable Railway API token. Required to create/delete services.", "isOptional": false },
-    "NEON_DATABASE_URL":  { "description": "Postgres URL for the IGLA audit ledger.", "isOptional": false },
+    "RAILWAY_TOKEN":         { "description": "Write-capable Railway API token. Required to create/delete services.", "isOptional": false },
+    "RAILWAY_POSTGRES_URL":  { "description": "Postgres URL for the IGLA audit ledger (primary; L-NEON-RENAME).",      "isOptional": true },
+    "NEON_DATABASE_URL":     { "description": "Legacy Postgres URL — fallback if RAILWAY_POSTGRES_URL is unset (L-NEON-RENAME).", "isOptional": true },
     "RUST_LOG":           { "description": "tracing-subscriber filter.", "default": "info" },
     "PORT":               { "description": "HTTP port (Railway convention).", "default": "8080" },
     "IGLA_PROJECT_UUID":  { "description": "Default project UUID. After DR-restore, fill with the new IGLA UUID.", "default": "e4fe33bb-3b09-4842-9782-7d2dea1abc9b" }


### PR DESCRIPTION
## Summary

Rename `NEON_DATABASE_URL` → `RAILWAY_POSTGRES_URL` across all source files and ops docs, **keeping `NEON_DATABASE_URL` as a legacy fallback when reading env**. Backing store moved off Neon onto Railway service `phd-postgres-ssot` in 2026-05.

> Legacy `NEON_DATABASE_URL` honored as fallback for transition. Source of truth: Railway service `phd-postgres-ssot` (project `e4fe33bb-3b09-4842-9782-7d2dea1abc9b`).

Migration is **non-breaking** by design — every read site checks the new var first and falls back to the legacy name. Existing deployments that still set only `NEON_DATABASE_URL` continue to work without any change. The actual sunset (delete the legacy fallback) is a separate follow-up PR after all runners are confirmed reading the new var.

## Files changed (31)

### Runtime code (Rust, TS, Python)
- `bin/seed-agent/src/main.rs` — clap `env="RAILWAY_POSTGRES_URL"` on `Option<String>` field; manual fallback in `main()` to legacy `NEON_DATABASE_URL`. Error messages list both.
- `bin/seed-agent/tests/smoke_test.rs` — `#[ignore]` reason updated.
- `bin/tri-gardener/src/bpb_source.rs` — `from_env()` uses `or_else` chain. Tracing log mentions both.
- `bin/tri-railway/src/main.rs` — `or_else` chain for the `audit migrate` path; doc comment updated.
- `crates/trios-railway-audit/src/event.rs` — doc-example updated.
- `crates/trios-railway-mcp/src/tools.rs` — 4 tool/instruction strings updated.
- `crates/trios-igla-race/src/bin/debug_queue.rs` — `Option<String>` + manual fallback.
- `crates/trios-igla-race/src/bin/reset_queue.rs` — CLI arg → `RAILWAY_POSTGRES_URL` → legacy `NEON_DATABASE_URL` priority chain.
- `crates/trios-igla-race/src/bin/scarab.rs` — module docstring + 2 `env::var` sites use `or_else` chain.
- `crates/trios-igla-race/src/bin/seed_agent.rs` — `Option<String>` + manual fallback.
- `crates/trios-igla-race/src/bin/seed_gardener.rs` — all 4 clap attrs + new helper `resolve_neon_url()`.
- `crates/trios-igla-race/Dockerfile.scarab` — comment updated.
- `.trinity/shiva-hub/src/index.ts` — `process.env.RAILWAY_POSTGRES_URL ?? process.env.NEON_DATABASE_URL ?? process.env.POSTGRES_URL`.
- `.trinity/shiva-hub/src/mcp-client.ts` — child env carries both names.
- `.trinity/promotion-artifacts/step-g-deploy-real-fleet.md` — Python `os.environ.get(...) or os.environ.get(...)` pattern + duplicate `("KEY", url)` tuple.

### CI / build / templates
- `.github/workflows/dr-restore.yml` — dual-export both env names side-by-side; psql step uses `${RAILWAY_POSTGRES_URL:-$NEON_DATABASE_URL}`.
- `Makefile` — `smoke-full` accepts either var.
- `railway-template.json` — `RAILWAY_POSTGRES_URL` added next to `NEON_DATABASE_URL` in 4 service variable blocks; `POSTGRES_HOST` description updated.
- `restore-fleet.json` — both `${secret:RAILWAY_POSTGRES_URL}` and `${secret:NEON_DATABASE_URL}` pushed into shared_vars.
- `schemas/restore-fleet.schema.json` — `neon_ddl` description references both names.
- `template.json` — same dual-entry pattern.

### SQL migrations + docs
- `migrations/0001_railway_audit.sql` — psql command in comment uses `"${RAILWAY_POSTGRES_URL:-$NEON_DATABASE_URL}"`.
- `migrations/0002_experiment_queue.sql` — same.
- `README.md` — same.
- `crates/trios-railway-smoke/README.md` — primary + commented-out legacy example.
- `docs/DR.md`, `docs/DISASTER_RECOVERY.md`, `docs/FLEET_OPERATIONS.md`, `docs/GARDENER_ONESHOT.md`, `docs/IMPROVEMENT_PLAN.md`, `docs/RESTORE_CLI_SPEC.md` — all `psql "$NEON_DATABASE_URL"` invocations rewritten to `${RAILWAY_POSTGRES_URL:-$NEON_DATABASE_URL}`; secret-table rows split into two lines.

## Precedence read-pattern by language

### Rust
```rust
let db_url = std::env::var("RAILWAY_POSTGRES_URL")
    .or_else(|_| std::env::var("NEON_DATABASE_URL"))
    .map_err(|_| anyhow::anyhow!("RAILWAY_POSTGRES_URL (or legacy NEON_DATABASE_URL) not set"))?;
```

### Rust + clap (where the field was clap-bound)
```rust
#[arg(long, env = "RAILWAY_POSTGRES_URL")]
neon_url: Option<String>,
// …
let neon_url: String = match cli.neon_url {
    Some(u) if !u.is_empty() => u,
    _ => std::env::var("NEON_DATABASE_URL").map_err(|_| {
        anyhow::anyhow!("RAILWAY_POSTGRES_URL (or legacy NEON_DATABASE_URL) not set")
    })?,
};
```

### TypeScript
```ts
const dbUrl =
  process.env.RAILWAY_POSTGRES_URL ??
  process.env.NEON_DATABASE_URL;
```

### Python
```python
db_url = (
    os.environ.get("RAILWAY_POSTGRES_URL")
    or os.environ.get("NEON_DATABASE_URL")
)
```

### Shell / docs
```bash
psql "${RAILWAY_POSTGRES_URL:-$NEON_DATABASE_URL}"
```

### GitHub Actions
```yaml
env:
  RAILWAY_POSTGRES_URL: ${{ secrets.RAILWAY_POSTGRES_URL }}
  NEON_DATABASE_URL:    ${{ secrets.NEON_DATABASE_URL }}
# …
- name: Apply audit DDL
  if: env.RAILWAY_POSTGRES_URL != '' || env.NEON_DATABASE_URL != ''
  run: |
    DB_URL="${RAILWAY_POSTGRES_URL:-$NEON_DATABASE_URL}"
    ./target/release/tri-railway audit migrate-sql | psql "$DB_URL"
```

## Files NOT touched (intentional skips per spec rule 4)

- `.trinity/experience/2026-04-29.md`, `2026-04-30.md`, `trios_railway_20260428.trinity` — historical event logs (append-only convention; the var name there is the value-of-the-day for that date).
- `.claude/plugins/igla/agents/igla-operator.md`, `hooks/monitor-experiments.md`, `skills/igla.md` — sensitive `.claude/` files (permission denied at edit time); these are agent prompt configs, non-runtime.

## Verification

```
cargo check --workspace          → clean
cargo test --workspace --lib --bins → all green
                                      (no env-name asserts in unit tests)
```

CI will re-run on push and gate the merge.

## Anchor

`phi^2 + phi^-2 = 3` · DOI [10.5281/zenodo.19227877](https://doi.org/10.5281/zenodo.19227877)