### PR TITLE
feat(sentinel): add audit_runs table migration (Closes #141)

### DIFF
--- a/migrations/0003_zenodo_sentinel_audit_runs.sql
+++ b/migrations/0003_zenodo_sentinel_audit_runs.sql
@@ -1,0 +1,19 @@
+-- Migration: audit_runs table for Zenodo Sentinel cron (skill_id a6d54f82, cron 1320bf84)
+-- Sibling to gardener_runs from migrations/0001_railway_audit.sql
+-- Tracked by: gHashTag/trios-railway#141
+-- R5 rule: every green verdict MUST store evidence JSON with counts/sha-pins/response-codes
+
+CREATE TABLE IF NOT EXISTS public.audit_runs (
+  id           BIGSERIAL PRIMARY KEY,
+  ts           TIMESTAMPTZ NOT NULL DEFAULT now(),
+  probe        TEXT NOT NULL,        -- bib_dup | ref_label | includegraphics | citation_cff | zenodo_community | doi_head | tectonic
+  verdict      TEXT NOT NULL,        -- green | yellow | red | skip
+  anomalies    JSONB NOT NULL DEFAULT '[]'::jsonb,
+  evidence     JSONB,
+  duration_ms  INTEGER
+);
+CREATE INDEX IF NOT EXISTS idx_audit_runs_ts ON public.audit_runs (ts DESC);
+CREATE INDEX IF NOT EXISTS idx_audit_runs_probe_ts ON public.audit_runs (probe, ts DESC);
+
+-- After this lands, the Zenodo Sentinel cron auto-flushes the workspace buffer
+-- (/home/user/workspace/zenodo_sentinel_buffer/*.json) via jsonb_array_elements on the first tick.


### PR DESCRIPTION
Closes #141

## What
Adds `migrations/0003_zenodo_sentinel_audit_runs.sql` — sibling to `0001_railway_audit.sql` (which defined `gardener_runs`).

## Why
Zenodo Sentinel cron `1320bf84` (skill `zenodo-sentinel` v1.1, skill_id `a6d54f82-fb34-4eee-a645-b57a77e32931`) has been ticking hourly at `:15 UTC` since 2026-05-13 04:27Z. Without `audit_runs`, every tick goes into **buffer-only mode** writing to `/home/user/workspace/zenodo_sentinel_buffer/<ISO-UTC>.json`. 7 ticks already buffered.

R5-verified blocker on Pipedream MCP DDL pathway (see #141 RCA): `postgresql-execute-custom-query` silently drops `CREATE TABLE`. Only repo migrations can apply DDL to `phd-postgres-ssot`.

## Schema rationale
Symmetric to `gardener_runs(id, ts, action, decision)`:

| Column | Type | Notes |
|---|---|---|
| `id` | `BIGSERIAL PRIMARY KEY` | match gardener_runs |
| `ts` | `TIMESTAMPTZ NOT NULL DEFAULT now()` | match gardener_runs |
| `probe` | `TEXT NOT NULL` | discriminator: `bib_dup` \| `ref_label` \| `includegraphics` \| `citation_cff` \| `zenodo_community` \| `doi_head` \| `tectonic` |
| `verdict` | `TEXT NOT NULL` | `green` \| `yellow` \| `red` \| `skip` |
| `anomalies` | `JSONB NOT NULL DEFAULT '[]'::jsonb` | array of finding objects |
| `evidence` | `JSONB` | counts, sha-pins, response-codes (R5: required for `green`) |
| `duration_ms` | `INTEGER` | per-probe timing |

Two indexes:
- `idx_audit_runs_ts` (ts DESC) — for "latest tick" queries
- `idx_audit_runs_probe_ts` (probe, ts DESC) — for green↔red flip detection

## Auto-flush after merge
The Zenodo Sentinel cron has STEP 0 existence-check baked in. First tick after this lands:
1. Sees `audit_runs` exists via `SELECT FROM information_schema.tables`
2. Inserts current tick (7 probes → 7 rows)
3. Flushes buffer: `INSERT INTO audit_runs (ts, probe, verdict, anomalies, evidence, duration_ms) SELECT ... FROM jsonb_array_elements($1::jsonb)` 
4. Removes flushed JSON files from `/home/user/workspace/zenodo_sentinel_buffer/`

## Validation already done (R5)
Direct query against `phd-postgres-ssot` from the main session:
- `SELECT count(*) FROM gardener_runs WHERE ts > now() - interval '24 hours'` → 18 rows ✅
- `SELECT table_name FROM information_schema.tables WHERE table_name='audit_runs'` → empty ❌ (root cause)

## Acceptance
- [x] Migration file added
- [ ] `audit_runs` exists in `public` schema after deploy
- [ ] Indexes `idx_audit_runs_ts`, `idx_audit_runs_probe_ts` exist
- [ ] Next cron tick (`:15 UTC`) writes 7 rows successfully
- [ ] Buffer files `/home/user/workspace/zenodo_sentinel_buffer/*.json` flushed and removed

Anchor: φ² + φ⁻² = 3 · Throne: gHashTag/trios#264
