### PR TITLE
feat(doctor): Layer-2 autonomous fleet doctor skeleton (skill docker-railway-doctor v1.2, ICA-103)

### DIFF
--- a/.github/workflows/doctor-loop.yml
+++ b/.github/workflows/doctor-loop.yml
@@ -1,0 +1,40 @@
+name: doctor-loop
+
+# Layer-2 autonomous Railway fleet doctor for trios-trainer-igla.
+# Bypass-discipline: lives in its own workflow + crate, does NOT modify
+# gardener-loop.yml (v2.9 / PR #149 territory). Skill: docker-railway-doctor v1.2.
+# Anchor: phi^2 + phi^-2 = 3 · TRINITY · NEVER STOP · DOI 10.5281/zenodo.19227877
+
+on:
+  schedule:
+    - cron: '*/5 * * * *'  # every 5 minutes (cron-tier monitor runs hourly)
+  workflow_dispatch:
+    inputs:
+      action:
+        description: 'doctor action: diagnose | cure | cure-all'
+        required: false
+        default: 'diagnose'
+
+concurrency:
+  group: doctor-loop
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  actions: write
+  issues: write
+
+jobs:
+  doctor:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Skeleton — Layer-2 doctor stub (PR #155, feat/doctor-v1.0)
+        run: |
+          echo "DOCTOR Layer-2 skeleton — not yet wired."
+          echo "Anchor: phi^2 + phi^-2 = 3"
+          echo "Action: ${{ inputs.action || 'diagnose' }}"
+          echo "Pending merge of crates/tri-doctor (PR #155)."
+          # TODO: invoke `cargo run -p tri-doctor -- $ACTION` once the crate lands.
+          # TODO: append row to public.gardener_runs with action='doctor_cure'.
+          # TODO: emit Railway serviceInstanceDeployV2 force-redeploys on AMBER.

--- a/crates/tri-doctor/Cargo.toml
+++ b/crates/tri-doctor/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "tri-doctor"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
+description = "Layer-1 autonomous Railway fleet doctor for trios-trainer-igla. Skill: docker-railway-doctor v1.2."
+
+[[bin]]
+name = "tri-doctor"
+path = "src/main.rs"
+
+[dependencies]
+anyhow = "1"
+clap = { version = "4", features = ["derive"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+sqlx = { version = "0.7", features = ["runtime-tokio-rustls", "postgres", "chrono"] }
+tokio = { version = "1", features = ["full"] }
+reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
+chrono = { version = "0.4", features = ["serde"] }

--- a/crates/tri-doctor/src/main.rs
+++ b/crates/tri-doctor/src/main.rs
@@ -1,0 +1,42 @@
+// tri-doctor — Layer-1 autonomous Railway fleet doctor.
+// Anchor: phi^2 + phi^-2 = 3 · TRINITY · NEVER STOP · DOI 10.5281/zenodo.19227877
+//
+// Skill: docker-railway-doctor v1.2 (Perplexity Computer user-scope).
+// This is a skeleton stub — actual cure logic lands in a follow-up PR.
+
+use anyhow::Result;
+use clap::{Parser, Subcommand};
+
+#[derive(Parser, Debug)]
+#[command(name = "tri-doctor", version, about = "Autonomous Railway fleet doctor")]
+struct Cli {
+    #[command(subcommand)]
+    command: Cmd,
+}
+
+#[derive(Subcommand, Debug)]
+enum Cmd {
+    /// Run R5-honest probes (writer pulse, bit-id, seq-burn, matrix champ) and emit JSON verdict.
+    Diagnose,
+    /// Apply a single cure-action: force-redeploy + variable upsert + GARDENER_LIVE flap.
+    Cure,
+    /// Apply all cure-actions in sequence (max 40 per Railway GraphQL quota).
+    CureAll,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let cli = Cli::parse();
+    match cli.command {
+        Cmd::Diagnose => {
+            println!("{{\"verdict\":\"AMBER\",\"reason\":\"skeleton-stub\",\"anchor\":\"phi^2+phi^-2=3\"}}");
+        }
+        Cmd::Cure => {
+            anyhow::bail!("cure not yet implemented — pending Layer-1 wiring");
+        }
+        Cmd::CureAll => {
+            anyhow::bail!("cure-all not yet implemented — pending Layer-1 wiring");
+        }
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Layer-2 autonomous Railway fleet doctor — skeleton PR

Auto-opened by Perplexity Computer (cycle-12 blocker elimination) to unblock **ICA-103** — Doctor Layer-2 deploy.

### Why
The hourly Doctor cron (\`17d63b6f\`, skill **docker-railway-doctor v1.2**) has been emitting AMBER bootstrap-pending verdicts for 8 consecutive ticks (RVR-001..008, 20:18 UTC → 05:17 UTC) because \`.github/workflows/doctor-loop.yml\` does not yet exist in this repo. Cron-tier MONITORS only — cure-actions must run in Layer 2.

Meanwhile the gardener writer has been dead since \`2026-05-13T19:26:40.738Z\` (\`stale_sec ≈ 36500\`, 10h+) with no recovery (B-12 gas-lighting, B-15 hourly-decay silent). PR #149 (gardener-v2.12) is the long-term fix but unmerged. Doctor is the **bypass** that revives the writer without waiting for #149.

### What this PR adds (skeleton only, NOT functional)
1. \`.github/workflows/doctor-loop.yml\` — 5-min schedule + manual dispatch + concurrency group \`doctor-loop\`. Currently a stub that logs and exits 0.
2. \`crates/tri-doctor/Cargo.toml\` — Layer-1 binary crate definition (anyhow / clap / sqlx / reqwest / tokio).
3. \`crates/tri-doctor/src/main.rs\` — CLI skeleton: \`diagnose | cure | cure-all\`. \`diagnose\` prints AMBER skeleton-stub JSON; \`cure\` / \`cure-all\` \`bail!\` until Layer-1 wiring lands.

### Follow-up PRs (NOT in scope)
- Wire \`tri-doctor diagnose\` into the workflow via \`cargo run -p tri-doctor -- diagnose\`.
- Implement \`tri-doctor cure\`: Railway GraphQL \`serviceInstanceDeployV2\` force-redeploy, \`variableUpsert TRIOS_TRAINER_IMAGE\`, \`GARDENER_LIVE\` flap.
- Append \`gardener_runs\` row with \`action='doctor_cure'\` after each cure-action.
- Hard rule: max 40 cure-actions per Railway quota window; NO DELETE, NO UPDATE.

### Verification
- \`tri-doctor\` crate compiles standalone (\`cargo build -p tri-doctor\`).
- Workflow YAML is lint-clean.
- Skill spec: docker-railway-doctor v1.2 changelog covers GH proxy quirk fix (cycle-11) + connector handshake (cycle-10).

### Anchor
\`phi^2 + phi^-2 = 3 · TRINITY · NEVER STOP · DOI 10.5281/zenodo.19227877\`

🤖 Auto-opened by Perplexity Computer · cycle-12 blocker elimination