### PR TITLE
fix(b-18): writer-env-fix uses Project-Access-Token (PAT) instead of Bearer

### DIFF
--- a/.github/workflows/writer-env-fix.yml
+++ b/.github/workflows/writer-env-fix.yml
@@ -56,7 +56,7 @@ jobs:
     env:
       TOKEN_ACC1: ${{ secrets.RAILWAY_TOKEN_ACC1 }}
       TOKEN_ACC2: ${{ secrets.RAILWAY_TOKEN_ACC2 }}
-      RAILWAY_TOKEN_AUTH: team
+      RAILWAY_TOKEN_AUTH: project  # B-18 fix (2026-05-14): all ACC1..7 tokens are project-scoped (PAT), not team. Verified by token-classify.yml run 25846091578.
       IGLA_PROJECT_ID: e4fe33bb-3b09-4842-9782-7d2dea1abc9b
       ACC2_PROJECT_ID: 12c508c7-1196-468d-b06d-d8de8cb77e93
       MCP_SERVICE_ID: db786a4b-5a79-4643-b915-e9184680cf97
@@ -78,18 +78,21 @@ jobs:
             echo "::error::RAILWAY_TOKEN_ACC2 secret is empty"
             exit 2
           fi
+          # B-18 fix: use Project-Access-Token (PAT) header + project-scoped query.
+          # The old Authorization: Bearer + { projects { edges } } pattern
+          # required an account/team token; all ACC1..7 secrets are PAT.
           for L in ACC1 ACC2; do
             T_VAR="TOKEN_${L}"
             T="${!T_VAR}"
             curl -sS -X POST https://backboard.railway.com/graphql/v2 \
                 -H "Content-Type: application/json" \
-                -H "Authorization: Bearer $T" \
-                -d '{"query":"{ projects { edges { node { id name } } } }"}' \
-                | jq -e '.data.projects.edges' > /dev/null || {
-                  echo "::error::token $L failed sanity check"
+                -H "Project-Access-Token: $T" \
+                -d '{"query":"{ projectToken { project { id name } } }"}' \
+                | jq -e '.data.projectToken.project.id' > /dev/null || {
+                  echo "::error::token $L failed sanity check (Project-Access-Token mode)"
                   exit 3
                 }
-            echo "token $L OK"
+            echo "token $L OK (PAT scope)"
           done
 
       - name: Apply fix to all reachable services
@@ -137,9 +140,12 @@ jobs:
           resolve_env() {
             local TOKEN="$1"
             local PROJECT_ID="$2"
+            # B-18 fix: PAT header instead of Authorization: Bearer.
+            # NOTE: project(id) query is implicit for PAT — the token already
+            # carries the project, but Railway still accepts an explicit projectId.
             curl -sS -X POST https://backboard.railway.com/graphql/v2 \
                 -H "Content-Type: application/json" \
-                -H "Authorization: Bearer $TOKEN" \
+                -H "Project-Access-Token: $TOKEN" \
                 -d "{\"query\":\"query env(\$projectId: String!){ project(id:\$projectId){ environments { edges { node { id name } } } } }\",\"variables\":{\"projectId\":\"$PROJECT_ID\"}}" \
                 | jq -r '.data.project.environments.edges[] | select(.node.name=="production") | .node.id' \
                 | head -n 1
@@ -150,9 +156,10 @@ jobs:
           fetch_services() {
             local TOKEN="$1"
             local PROJECT_ID="$2"
+            # B-18 fix: PAT header.
             curl -sS -X POST https://backboard.railway.com/graphql/v2 \
                 -H "Content-Type: application/json" \
-                -H "Authorization: Bearer $TOKEN" \
+                -H "Project-Access-Token: $TOKEN" \
                 -d "{\"query\":\"query svcs(\$projectId: String!){ project(id:\$projectId){ services { edges { node { id name } } } } }\",\"variables\":{\"projectId\":\"$PROJECT_ID\"}}" \
                 | jq '[.data.project.services.edges[].node]'
           }
@@ -193,9 +200,10 @@ jobs:
                 --arg v "$VALUE" \
                 '{query:"mutation variableUpsert($input: VariableUpsertInput!) { variableUpsert(input: $input) }", variables:{input:{projectId:$p, environmentId:$e, serviceId:$s, name:$n, value:$v}}}')
             local RESP
+            # B-18 fix: PAT header.
             RESP=$(curl -sS -X POST https://backboard.railway.com/graphql/v2 \
                 -H "Content-Type: application/json" \
-                -H "Authorization: Bearer $TOKEN" \
+                -H "Project-Access-Token: $TOKEN" \
                 -d "$PAYLOAD")
             if echo "$RESP" | jq -e '.errors' > /dev/null; then
               echo "    upsert $NAME: ERR — $(echo "$RESP" | jq -c '.errors')"
@@ -216,9 +224,10 @@ jobs:
                 --arg e "$ENV_ID" \
                 '{query:"mutation serviceInstanceRedeploy($serviceId: String!, $environmentId: String!) { serviceInstanceRedeploy(serviceId: $serviceId, environmentId: $environmentId) }", variables:{serviceId:$s, environmentId:$e}}')
             local RESP
+            # B-18 fix: PAT header.
             RESP=$(curl -sS -X POST https://backboard.railway.com/graphql/v2 \
                 -H "Content-Type: application/json" \
-                -H "Authorization: Bearer $TOKEN" \
+                -H "Project-Access-Token: $TOKEN" \
                 -d "$PAYLOAD")
             if echo "$RESP" | jq -e '.errors' > /dev/null; then
               echo "    redeploy: ERR — $(echo "$RESP" | jq -c '.errors')"


### PR DESCRIPTION
## B-18 · writer-env-fix.yml uses wrong auth mode for Railway PAT tokens

### Diagnosis (R5-verified)

[token-classify.yml run 25846091578](https://github.com/gHashTag/trios-railway/actions/runs/25846091578) (2026-05-14 06:43 UTC) proved that ALL 7 `RAILWAY_TOKEN_ACC1..7` secrets are **project-access-tokens (PAT)**, not account/team tokens:

```
ACC1: PAT/projectToken: {"id":"f29aa9dd-ca0b-460f-ad24-c7680c6717fb","name":"IGLA RACE"} ✅
ACC2: PAT/projectToken: {"id":"ad0f8f04-c56d-4b11-9350-cc0c2700b9db","name":"IGLA"}      ✅
ACC3: PAT/projectToken: {"id":"475a2290-d990-426a-af57-594a934cf6f4","name":"robust-radiance"} ✅
ACC4..7: all valid PAT tokens — see run log
```

(`Bearer/me` → "Not Authorized" — expected behaviour for PAT.)

### Root cause

`writer-env-fix.yml` sends `Authorization: Bearer <token>` with `{ projects { edges } }` query — this combination requires an **account/team token**, returns `data.projects.edges = null` for PAT, sanity-check exits with code 3.

### Why this PR

Aligns `writer-env-fix.yml` with the **proven-working pattern** from `refresh-acc47.yml` (last successful run [25754312720](https://github.com/gHashTag/trios-railway/actions/runs/25754312720), 2026-05-12 18:31 UTC):

```diff
- -H "Authorization: Bearer $T"
+ -H "Project-Access-Token: $T"

- -d '{"query":"{ projects { edges { node { id name } } } }"}'
+ -d '{"query":"{ projectToken { project { id name } } }"}'

- RAILWAY_TOKEN_AUTH: team
+ RAILWAY_TOKEN_AUTH: project
```

Also references `crates/trios-railway-core/src/transport.rs`:
> `project` sends `Project-Access-Token: <token>` and is required for project-scoped tokens (which is what the IGLA workspace token currently is).

### Change scope (6 replacements)

1. `Sanity-check tokens` step — uses PAT header + `projectToken` query
2. `resolve_env()` helper — PAT header
3. `fetch_services()` helper — PAT header
4. `upsert_var()` helper — PAT header
5. `redeploy()` helper — PAT header
6. `env.RAILWAY_TOKEN_AUTH: team` → `project` (with R5 comment)

### Verification plan (post-merge)

```bash
gh workflow run writer-env-fix.yml --repo gHashTag/trios-railway -f confirm=PHI
gh run watch  # expect "token ACC1 OK (PAT scope) / token ACC2 OK (PAT scope)"
```

Then within T+15min:
```sql
SELECT MAX(ts), EXTRACT(EPOCH FROM (NOW()-MAX(ts)))::int AS stale_sec
FROM ssot.bpb_samples WHERE canon_name LIKE 'IGLA-SHORT-WAVE-MATRIX-%';
-- expect stale_sec < 600
```

### Why this matters

Writer service `ssot.bpb_samples` is dead since `2026-05-13T19:26:40Z` (~10h 53m at time of writing). Doctor Layer-2 (PR #155) still draft. This fix is the last operator-mergeable unblock before the hive can self-heal.

### Refs

- Closes #158 (B-17, misdiagnosed as token-expiry; was actually wrong auth mode)
- B-12 #151 (gas-lighting — symptom of this bug)
- B-16 (Stage 2d "159 redeployed" claim — symptom of this bug)
- refresh-acc47.yml — proven-working PAT pattern
- `crates/trios-railway-core/src/transport.rs` — `AuthMode::Project` source of truth

Anchor: `φ² + φ⁻² = 3 · TRINITY · NEVER STOP · DOI 10.5281/zenodo.19227877`
