### PR TITLE
feat(migrations): 0007 expand scarab_strategy format CHECK to full FormatKind::all() — resolves #182

### DIFF
--- a/migrations/0007_scarab_strategy_format_full_whitelist.sql
+++ b/migrations/0007_scarab_strategy_format_full_whitelist.sql
@@ -1,0 +1,54 @@
+-- Migration 0007: Expand ssot.scarab_strategy.format CHECK to full trainer-igla FormatKind::all()
+--
+-- Anchor: phi^2 + phi^-2 = 3 · DOI 10.5281/zenodo.19227877
+-- Resolves: trios-railway#182
+-- Trainer ref: gHashTag/trios-trainer-igla:src/fake_quant.rs::FormatKind::all() @ 0affa84
+--
+-- Before this migration, only 12 formats were accepted, blocking Tier-1 gf-midrange
+-- (gf4/gf8/gf32/gf64), Tier-2 (MX, posit8/32), and 49 other unmeasured formats.
+-- This migration expands the whitelist to all 70 canonical formats from the trainer.
+
+ALTER TABLE ssot.scarab_strategy
+    DROP CONSTRAINT IF EXISTS scarab_strategy_format_check;
+
+ALTER TABLE ssot.scarab_strategy
+    ADD CONSTRAINT scarab_strategy_format_check CHECK (format = ANY (ARRAY[
+        -- IEEE float (4 narrow + 4 wide)
+        'fp16','bf16','tf32','fp32','fp64','fp80','binary16','binary32','binary128','binary256','f32',
+        -- OCP small float (5)
+        'fp8_e4m3','fp8_e5m2','fp6_e3m2','fp6_e2m3','fp4_e2m1',
+        -- MX Microscaling (3)
+        'mxfp4','mxfp6','mxfp8',
+        -- Galois Field / Trinity canon (9)
+        'gf4','gf8','gf12','gf16','gf20','gf24','gf32','gf64','gf256',
+        -- Integer (5)
+        'int4','int8','int16','int32','uint8',
+        -- NormalFloat / QLoRA (2)
+        'nf4','nf8',
+        -- Posit (4)
+        'posit8','posit16','posit32','posit64',
+        -- Logarithmic (1)
+        'lns8',
+        -- Decimal (3)
+        'decimal32','decimal64','decimal128',
+        -- Stochastic / advanced (6)
+        'stochastic_rnd','stochastic_round','tapered_fp','block_fp','shared_exp','afp',
+        -- Unum exotics (6)
+        'unum_i','unum_ii','unum_i8','unum_i16','unum_ii8','unum_ii16',
+        -- Q-format DSP (3)
+        'q_format','q15','q31',
+        -- BCD (3)
+        'bcd','bcd8','bcd16',
+        -- IBM HFP legacy (3)
+        'ibm_hfp','ibm_hfp_short','ibm_hfp_long',
+        -- VAX float legacy (4)
+        'vax_f','vax_d','vax_g','vax_h',
+        -- Cray / minifloat (2)
+        'cray_float','minifloat'
+    ]::text[]));
+
+-- Sanity: format column unchanged, but write protocol now accepts the full trainer registry.
+-- Note: 15 of these (fp64, fp80, binary128/256, decimal64/128, vax_d/g/h, cray_float,
+-- ibm_hfp_long, posit64, stochastic_rnd, stochastic_round, q31) are UNSUPPORTED in
+-- the f32 simulator and silently identity-pass — runtime guard lives in the trainer,
+-- not the DB. CHECK only enforces canonical-spelling discipline.


### PR DESCRIPTION
## Resolves
[#182](https://github.com/gHashTag/trios-railway/issues/182) — P1 blocker: scarab_strategy.format CHECK rejects 53 trainer-supported formats.

## Change
Migration `0007_scarab_strategy_format_full_whitelist.sql` expands the CHECK whitelist from 12 to 70 canonical formats, mirroring `trios-trainer-igla:src/fake_quant.rs::FormatKind::all()` @ `0affa84`.

## Unblocks
- **Tier-1** Galois-midrange (`gf4/gf8/gf32/gf64`) — bridges `gf16=2.72 / gf256=2.57` gap
- **Tier-2** MX (`mxfp4/6/8`), Posit (`posit8/32`)
- **Tier-3** NormalFloat-8 (`nf8`), Logarithmic (`lns8`)
- 49 additional unmeasured formats

## R5
- 15 formats marked UNSUPPORTED in f32 simulator (silently identity-pass) — runtime guard remains in trainer, CHECK enforces canonical-spelling only.
- Idempotent (`DROP CONSTRAINT IF EXISTS`); applied via existing `.github/workflows/apply-migrations.yml` on merge to main.

Anchor: phi^2 + phi^-2 = 3 · NEVER STOP · DOI 10.5281/zenodo.19227877