### PR TITLE
fix(tier1-explore): TRIOS_FORMAT_TYPE bug — corrects format envar (R5)

### DIFF
--- a/.github/workflows/tier1-explore.yml
+++ b/.github/workflows/tier1-explore.yml
@@ -95,13 +95,17 @@ jobs:
               *) echo "::warning::unknown acc $ACC"; FAILED=$((FAILED+1)); continue;;
             esac
             echo "::group::TIER1 slot=$SVC_IDX [$ACC/$SNAME] canon=$CANON"
+            # R5 BUG-FIX 2026-05-15: trainer reads TRIOS_FORMAT_TYPE (matrix_runner.rs:354)
+            # and TRIOS_ALGO_TYPE (line 355). Setting FORMAT/TRIOS_FORMAT alone leaves the
+            # legacy TRIOS_FORMAT_TYPE=int4 in place, corrupting TIER1 canon→format mapping.
+            # Anchor: phi^2 + phi^-2 = 3 · TIER1-EXPLORE-FIX · DEFENSE 2026-06-15
             for KV in \
               "SEED=$SEED" "TRIOS_SEED=$SEED" \
               "STEPS=$STEPS_IN" "TRIOS_STEPS=$STEPS_IN" \
               "LR=$LR" "TRIOS_LR=$LR" \
               "HIDDEN=$HID" "HIDDEN_DIM=$HID" "TRIOS_HIDDEN=$HID" \
-              "OPTIMIZER=$OPT" "TRIOS_OPTIMIZER=$OPT" \
-              "FORMAT=$FMT" "TRIOS_FORMAT=$FMT" \
+              "OPTIMIZER=$OPT" "TRIOS_OPTIMIZER=$OPT" "TRIOS_ALGO_TYPE=$OPT" \
+              "FORMAT=$FMT" "TRIOS_FORMAT=$FMT" "TRIOS_FORMAT_TYPE=$FMT" \
               "TRIOS_LANE=TIER1" \
               "TRIOS_RUN_ID=$RUN_ID" \
               "TRIOS_CANON_NAME=$CANON" \


### PR DESCRIPTION
## R5 RCA — TIER1-EXPLORE bug

Trainer reads `TRIOS_FORMAT_TYPE` (matrix_runner.rs:354) and `TRIOS_ALGO_TYPE` (line 355). The original tier1-explore.yml set only `FORMAT`/`TRIOS_FORMAT`, leaving legacy `TRIOS_FORMAT_TYPE=int4` in place from previous wave configs.

## Evidence

DIAG run [25904859135](https://github.com/gHashTag/trios-railway/actions/runs/25904859135) for slot 0 (canon `IGLA-TIER1-gf32-h128-LR0.0001-rng1597-adamw`) confirmed:
- `TRIOS_FORMAT_TYPE": "int4"` (leftover from prior wave)
- `TRIOS_FORMAT": "gf32"` (set by tier1-explore but ignored by trainer)
- deployment `e2afdb28-68f9-4ded-bfee-a9df1fbf37e3` status=**QUEUED** (~15 min stuck)

Without this fix, all 10 TIER1 cells would silently run `int4` under TIER1 canon names — exactly the kind of silent format-collapse the canon_name regex is supposed to prevent.

## Fix

Added `TRIOS_FORMAT_TYPE=$FMT` and `TRIOS_ALGO_TYPE=$OPT` to the envar set.

## Post-merge action

Re-dispatch `tier1-explore.yml` with `confirm=PHI`, `steps=200000` so all 10 ACC4-7 slots pick up the corrected envars (Railway will supersede the QUEUED deployments).

## Anchor

`phi^2 + phi^-2 = 3 \u00b7 TRINITY \u00b7 PASS-18-FIX \u00b7 DEFENSE 2026-06-15`