### PR TITLE
feat(workflows): MASS-REVIVE-STRATEGY — apply ssot.scarab_strategy to 18 idle services

### DIFF
--- a/.github/workflows/mass-revive-strategy.yml
+++ b/.github/workflows/mass-revive-strategy.yml
@@ -1,0 +1,163 @@
+name: MASS-REVIVE-STRATEGY — apply ssot.scarab_strategy → variableUpsert + redeploy
+
+# AUTONOMOUS REVIVAL of the 18 strategy rows held by the queen-hive scheduler.
+# `ssot.scarab_strategy` lists (service_id, account, format, optimizer, hidden,
+# lr, seed, steps). For every active row we:
+#   1. Build CANON = IGLA-STRATEGY-{format}-h{hidden}-LR{lr}-rng{seed}-{optimizer}
+#   2. variableUpsert FORMAT/OPTIMIZER/HIDDEN/SEED/LR/STEPS/TRIOS_CANON_NAME/
+#      RAILWAY_POSTGRES_URL/L_R8_SYNTHETIC_FALLBACK=FORBID/RUST_LOG=info to that
+#      service_id via Railway GraphQL.
+#   3. serviceInstanceDeployV2 to kick redeploy.
+#
+# Account → token mapping is read from RAILWAY_TOKEN_ACC1..ACC7 secrets.
+# project_id / environment_id are looked up from ssot.scarab_service_registry
+# (same source of truth used by the queen-hive). If a row is missing in that
+# registry we use the legacy default-project map from .github/wave-a/*.csv.
+#
+# Designed to run after MASS-REVIVE strategy rows are populated. Re-running is
+# idempotent — variableUpsert overwrites and redeploy just kicks a fresh build.
+#
+# Anchor: phi^2 + phi^-2 = 3 · TRINITY · NEVER STOP · DEFENSE 2026-06-15
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: "Type PHI to confirm strategy-driven mass revive"
+        required: true
+      dry_run:
+        description: "If true, only print planned actions (no variableUpsert / no deploy)"
+        required: false
+        default: "false"
+
+jobs:
+  mass-revive:
+    if: ${{ inputs.confirm == 'PHI' }}
+    runs-on: ubuntu-24.04
+    env:
+      T1: ${{ secrets.RAILWAY_TOKEN_ACC1 }}
+      T2: ${{ secrets.RAILWAY_TOKEN_ACC2 }}
+      T3: ${{ secrets.RAILWAY_TOKEN_ACC3 }}
+      T4: ${{ secrets.RAILWAY_TOKEN_ACC4 }}
+      T5: ${{ secrets.RAILWAY_TOKEN_ACC5 }}
+      T6: ${{ secrets.RAILWAY_TOKEN_ACC6 }}
+      T7: ${{ secrets.RAILWAY_TOKEN_ACC7 }}
+      RAILWAY_POSTGRES_URL: ${{ secrets.RAILWAY_POSTGRES_URL }}
+      DRY_RUN: ${{ inputs.dry_run }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install psql client
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq postgresql-client
+
+      - name: Pull strategy & apply variableUpsert + redeploy
+        run: |
+          set -e
+          # Strategy is the canonical source. project_id/env_id resolved from CSV fallback.
+          psql "$RAILWAY_POSTGRES_URL" -A -F'|' -t -c "
+            SELECT service_id, account, format, optimizer, hidden, lr, seed, steps,
+                   '' AS project_id, '' AS env_id, '' AS name
+            FROM ssot.scarab_strategy
+            WHERE status = 'active'
+            ORDER BY account, service_id
+          " > strategy.txt
+          echo "Strategy rows ($(wc -l < strategy.txt)):"
+          cat strategy.txt
+
+          # ====== apply variableUpsert + redeploy ======
+          DEPLOYED=0
+          FAILED=0
+          SKIPPED=0
+          TOTAL=0
+
+          # Fallback acc→default-project/env from registry mismatch.
+          # Read trainer-services.csv + acc47-services.csv to recover proj/env
+          # by service_id when registry has nothing.
+          mapfile -t FALLBACK_LINES < <(cat .github/wave-a/trainer-services.csv .github/wave-a/acc47-services.csv)
+
+          while IFS='|' read -r SID ACC FMT ALGO HIDDEN LR SEED STEPS PROJ ENV SNAME; do
+            TOTAL=$((TOTAL+1))
+            if [[ -z "$PROJ" || -z "$ENV" ]]; then
+              # Fallback: lookup by service_id in CSVs
+              for LINE in "${FALLBACK_LINES[@]}"; do
+                CSV_SID=$(echo "$LINE" | awk -F'","' '{print $4}')
+                if [[ "$CSV_SID" == "$SID" ]]; then
+                  PROJ=$(echo "$LINE" | awk -F'","' '{print $2}')
+                  ENV=$(echo "$LINE" | awk -F'","' '{print $3}')
+                  SNAME=$(echo "$LINE" | awk -F'","' '{print $5}' | tr -d '"')
+                  break
+                fi
+              done
+            fi
+            if [[ -z "$PROJ" || -z "$ENV" ]]; then
+              echo "::warning::skip svc=$SID ($ACC $FMT $ALGO seed=$SEED) — no project/env found"
+              SKIPPED=$((SKIPPED+1))
+              continue
+            fi
+            case "$ACC" in
+              ACC1) TOK="$T1";;
+              ACC2) TOK="$T2";;
+              ACC3) TOK="$T3";;
+              ACC4) TOK="$T4";;
+              ACC5) TOK="$T5";;
+              ACC6) TOK="$T6";;
+              ACC7) TOK="$T7";;
+              *) echo "::warning::unknown acc $ACC"; SKIPPED=$((SKIPPED+1)); continue;;
+            esac
+            if [[ -z "$TOK" ]]; then
+              echo "::warning::no token for $ACC"; SKIPPED=$((SKIPPED+1)); continue
+            fi
+
+            # Build canon name. LR formatted same as DEEP-CHAMPION canons.
+            CANON="IGLA-STRATEGY-${FMT}-h${HIDDEN}-LR${LR}-rng${SEED}-${ALGO}"
+            RUN_ID="strategy-${FMT}-h${HIDDEN}-LR${LR}-rng${SEED}-${ALGO}"
+
+            echo "::group::REVIVE svc=$SID [$ACC/${SNAME:-unknown}] $FMT/$ALGO/h$HIDDEN/seed=$SEED/LR=$LR/STEPS=$STEPS canon=$CANON"
+
+            if [[ "$DRY_RUN" == "true" ]]; then
+              echo "DRY_RUN: would variableUpsert + deploy svc=$SID canon=$CANON"
+              DEPLOYED=$((DEPLOYED+1))
+              echo "::endgroup::"
+              continue
+            fi
+
+            for KV in \
+              "SEED=$SEED" "TRIOS_SEED=$SEED" \
+              "STEPS=$STEPS" "TRIOS_STEPS=$STEPS" \
+              "LR=$LR" "TRIOS_LR=$LR" \
+              "HIDDEN=$HIDDEN" "HIDDEN_DIM=$HIDDEN" "TRIOS_HIDDEN=$HIDDEN" \
+              "OPTIMIZER=$ALGO" "TRIOS_OPTIMIZER=$ALGO" \
+              "FORMAT=$FMT" "TRIOS_FORMAT=$FMT" \
+              "TRIOS_RUN_ID=$RUN_ID" \
+              "TRIOS_CANON_NAME=$CANON" \
+              "RAILWAY_POSTGRES_URL=$RAILWAY_POSTGRES_URL" \
+              "RUST_LOG=info" \
+              "L_R8_SYNTHETIC_FALLBACK=FORBID" \
+            ; do
+              K="${KV%%=*}"; V="${KV#*=}"
+              curl -sS -X POST https://backboard.railway.com/graphql/v2 \
+                -H "Content-Type: application/json" \
+                -H "Project-Access-Token: $TOK" \
+                -d "$(jq -n --arg p "$PROJ" --arg e "$ENV" --arg s "$SID" --arg k "$K" --arg v "$V" '
+                  {query:"mutation($i:VariableUpsertInput!){variableUpsert(input:$i)}",
+                   variables:{i:{projectId:$p, environmentId:$e, serviceId:$s, name:$k, value:$v}}}')" > /dev/null
+            done
+            DEP=$(curl -sS -X POST https://backboard.railway.com/graphql/v2 \
+              -H "Content-Type: application/json" \
+              -H "Project-Access-Token: $TOK" \
+              -d "$(jq -n --arg s "$SID" --arg e "$ENV" '
+                {query:"mutation($s:String!,$e:String!){serviceInstanceDeployV2(serviceId:$s, environmentId:$e)}",
+                 variables:{s:$s, e:$e}}')" | jq -r '.data.serviceInstanceDeployV2 // "FAIL"')
+            if [[ "$DEP" == "FAIL" || -z "$DEP" || "$DEP" == "null" ]]; then
+              echo "::error::deploy failed svc=$SID canon=$CANON"
+              FAILED=$((FAILED+1))
+            else
+              echo "deploy_id=$DEP canon=$CANON"
+              DEPLOYED=$((DEPLOYED+1))
+            fi
+            echo "::endgroup::"
+            sleep 1
+          done < strategy.txt
+
+          echo "MASS-REVIVE-SUMMARY: total=$TOTAL deployed=$DEPLOYED failed=$FAILED skipped=$SKIPPED dry_run=$DRY_RUN"
+          if [[ $TOTAL -eq 0 ]]; then echo '::error::no strategy rows'; exit 1; fi
+          if [[ $FAILED -gt 0 ]]; then exit 1; fi

--- a/.github/workflows/tier2-explore.yml
+++ b/.github/workflows/tier2-explore.yml
@@ -1,0 +1,151 @@
+name: TIER2-EXPLORE — 14 more unexplored format families on ACC4-7
+
+# Builds on TIER1-EXPLORE (10 formats deployed 2026-05-15T06:49Z covering
+# gf{4,8,32,64}, posit{8,32}, mxfp{6,8}, nf8, lns8). With format CHECK now
+# at 70 entries (PR #183 migration 0007), Tier-2 extends coverage to 14 more
+# families across all 4 ACC4-7 accounts:
+#
+#   Slot ACC  Canon                                                          Why
+#   ---  ---  -----------------------------------------------------------    ---------------------------------------
+#   4   ACC4 IGLA-TIER2-mxfp4-h128-LR0.0001-rng1597-adamw                    MX 4-bit (industry standard for inference)
+#   5   ACC4 IGLA-TIER2-int6-h128-LR0.0001-rng1597-adamw                     INT6 between int4=2.71 and int8 (gap probe)
+#   6   ACC4 IGLA-TIER2-int2-h128-LR0.0001-rng1597-adamw                     INT2 super-low-bit (ternary-adjacent)
+#   7   ACC4 IGLA-TIER2-int3-h128-LR0.0001-rng1597-adamw                     INT3 (rare, ternary+1)
+#   8   ACC5 IGLA-TIER2-nf6-h128-LR0.0001-rng1597-adamw                      NF6 between nf4=7.06 and fp16=2.67
+#   9   ACC5 IGLA-TIER2-nf2-h128-LR0.0001-rng1597-adamw                      NF2 super-low-bit NormalFloat
+#   10  ACC5 IGLA-TIER2-bf16-h128-LR0.0001-rng1597-adamw                     bfloat16 vs fp16=2.67 (mantissa/exponent tradeoff)
+#   11  ACC5 IGLA-TIER2-tf32-h128-LR0.0001-rng1597-adamw                     TensorFloat32 (NVIDIA standard)
+#   33  ACC6 IGLA-TIER2-posit6-h128-LR0.0001-rng1597-adamw                   Posit-6 silicon-friendly
+#   34  ACC6 IGLA-TIER2-posit4-h128-LR0.0001-rng1597-adamw                   Posit-4 super-aggressive tapered
+#   35  ACC6 IGLA-TIER2-lns4-h128-LR0.0001-rng1597-adamw                     LNS-4 (log number system, 4-bit)
+#   59  ACC7 IGLA-TIER2-lns16-h128-LR0.0001-rng1597-adamw                    LNS-16 (calculator-grade precision)
+#   85  ACC7 IGLA-TIER2-binary8-h128-LR0.0001-rng1597-adamw                  IEEE binary8 (P3109 draft)
+#   86  ACC7 IGLA-TIER2-flexpoint-h128-LR0.0001-rng1597-adamw                Intel Flexpoint (block-floating-point)
+#
+# All cells: STEPS=200000, HIDDEN=128, LR=0.0001, SEED=1597, OPT=adamw.
+# Whitelist: matrix_runner.rs:67 ALGO_WHITELIST = {adamw, muon} — adamw safe.
+# Format CHECK: scarab_strategy_format_check expanded 2026-05-15T06:42Z to 70 formats.
+# Format support: confirmed in fake_quant.rs:449-493 (trainer-side FormatKind::all()).
+#
+# Anchor: phi^2 + phi^-2 = 3 · TRINITY · TIER2-EXPLORE · DEFENSE 2026-06-15
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: "Type PHI to confirm 14-cell exploration"
+        required: true
+      steps:
+        description: "Steps per cell"
+        required: true
+        default: "200000"
+
+jobs:
+  explore:
+    if: ${{ inputs.confirm == 'PHI' }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    env:
+      T4: ${{ secrets.RAILWAY_TOKEN_ACC4 }}
+      T5: ${{ secrets.RAILWAY_TOKEN_ACC5 }}
+      T6: ${{ secrets.RAILWAY_TOKEN_ACC6 }}
+      T7: ${{ secrets.RAILWAY_TOKEN_ACC7 }}
+      RAILWAY_POSTGRES_URL: ${{ secrets.RAILWAY_POSTGRES_URL }}
+      STEPS_IN: ${{ inputs.steps }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Reconfigure 14 ACC4-7 slots for TIER2-EXPLORE
+        run: |
+          set -e
+          mapfile -t SERVICES < .github/wave-a/acc47-services.csv
+          # Slot index → "FORMAT|HIDDEN|LR|SEED|OPT"
+          declare -A SLOT_CFG
+          SLOT_CFG[4]="mxfp4|128|0.0001|1597|adamw"
+          SLOT_CFG[5]="int6|128|0.0001|1597|adamw"
+          SLOT_CFG[6]="int2|128|0.0001|1597|adamw"
+          SLOT_CFG[7]="int3|128|0.0001|1597|adamw"
+          SLOT_CFG[8]="nf6|128|0.0001|1597|adamw"
+          SLOT_CFG[9]="nf2|128|0.0001|1597|adamw"
+          SLOT_CFG[10]="bf16|128|0.0001|1597|adamw"
+          SLOT_CFG[11]="tf32|128|0.0001|1597|adamw"
+          SLOT_CFG[33]="posit6|128|0.0001|1597|adamw"
+          SLOT_CFG[34]="posit4|128|0.0001|1597|adamw"
+          SLOT_CFG[35]="lns4|128|0.0001|1597|adamw"
+          SLOT_CFG[59]="lns16|128|0.0001|1597|adamw"
+          SLOT_CFG[85]="binary8|128|0.0001|1597|adamw"
+          SLOT_CFG[86]="flexpoint|128|0.0001|1597|adamw"
+          PROCESSED=0; DEPLOYED=0; FAILED=0
+          for SVC_IDX in 4 5 6 7 8 9 10 11 33 34 35 59 85 86; do
+            SVC_LINE="${SERVICES[$SVC_IDX]}"
+            if [[ -z "$SVC_LINE" ]]; then
+              echo "::warning::slot $SVC_IDX is empty in acc47-services.csv"
+              FAILED=$((FAILED+1))
+              continue
+            fi
+            CFG="${SLOT_CFG[$SVC_IDX]}"
+            FMT=$(echo "$CFG" | cut -d'|' -f1)
+            HID=$(echo "$CFG" | cut -d'|' -f2)
+            LR=$(echo "$CFG" | cut -d'|' -f3)
+            SEED=$(echo "$CFG" | cut -d'|' -f4)
+            OPT=$(echo "$CFG" | cut -d'|' -f5)
+            # acc47-services.csv format: ACC,proj,env,sid,sname (no quotes)
+            ACC=$(echo "$SVC_LINE" | awk -F',' '{print $1}')
+            PROJ=$(echo "$SVC_LINE" | awk -F',' '{print $2}')
+            ENV=$(echo "$SVC_LINE" | awk -F',' '{print $3}')
+            SID=$(echo "$SVC_LINE" | awk -F',' '{print $4}')
+            SNAME=$(echo "$SVC_LINE" | awk -F',' '{print $5}')
+            CANON="IGLA-TIER2-${FMT}-h${HID}-LR${LR}-rng${SEED}-${OPT}"
+            RUN_ID="tier2-explore-2026-05-15-${FMT}-${OPT}-h${HID}-LR${LR}-rng${SEED}"
+            case "$ACC" in
+              ACC4) TOK="$T4";;
+              ACC5) TOK="$T5";;
+              ACC6) TOK="$T6";;
+              ACC7) TOK="$T7";;
+              *) echo "::warning::unknown acc $ACC"; FAILED=$((FAILED+1)); continue;;
+            esac
+            echo "::group::TIER2 slot=$SVC_IDX [$ACC/$SNAME] canon=$CANON"
+            for KV in \
+              "SEED=$SEED" "TRIOS_SEED=$SEED" \
+              "STEPS=$STEPS_IN" "TRIOS_STEPS=$STEPS_IN" \
+              "LR=$LR" "TRIOS_LR=$LR" \
+              "HIDDEN=$HID" "HIDDEN_DIM=$HID" "TRIOS_HIDDEN=$HID" \
+              "OPTIMIZER=$OPT" "TRIOS_OPTIMIZER=$OPT" \
+              "FORMAT=$FMT" "TRIOS_FORMAT=$FMT" \
+              "TRIOS_LANE=TIER2" \
+              "TRIOS_RUN_ID=$RUN_ID" \
+              "TRIOS_CANON_NAME=$CANON" \
+              "RAILWAY_POSTGRES_URL=$RAILWAY_POSTGRES_URL" \
+              "RUST_LOG=info" \
+              "L_R8_SYNTHETIC_FALLBACK=FORBID" \
+            ; do
+              K="${KV%%=*}"; V="${KV#*=}"
+              curl -sS -X POST https://backboard.railway.com/graphql/v2 \
+                -H "Content-Type: application/json" \
+                -H "Project-Access-Token: $TOK" \
+                -d "$(jq -n --arg p "$PROJ" --arg e "$ENV" --arg s "$SID" --arg k "$K" --arg v "$V" '
+                  {query:"mutation($i:VariableUpsertInput!){variableUpsert(input:$i)}",
+                   variables:{i:{projectId:$p, environmentId:$e, serviceId:$s, name:$k, value:$v}}}')" > /dev/null
+            done
+            DEP=$(curl -sS -X POST https://backboard.railway.com/graphql/v2 \
+              -H "Content-Type: application/json" \
+              -H "Project-Access-Token: $TOK" \
+              -d "$(jq -n --arg s "$SID" --arg e "$ENV" '
+                {query:"mutation($s:String!,$e:String!){serviceInstanceDeployV2(serviceId:$s, environmentId:$e)}",
+                 variables:{s:$s, e:$e}}')" | jq -r '.data.serviceInstanceDeployV2 // "FAIL"')
+            if [[ "$DEP" == "FAIL" || -z "$DEP" || "$DEP" == "null" ]]; then
+              echo "::error::deploy failed slot=$SVC_IDX"
+              FAILED=$((FAILED+1))
+            else
+              echo "deploy_id=$DEP"
+              DEPLOYED=$((DEPLOYED+1))
+            fi
+            PROCESSED=$((PROCESSED+1))
+            echo "::endgroup::"
+            sleep 1
+          done
+          echo "TIER2-SUMMARY: processed=$PROCESSED deployed=$DEPLOYED failed=$FAILED"
+          if [[ $DEPLOYED -lt 8 ]]; then
+            echo "::error::critical: fewer than 8 of 14 cells deployed"
+            exit 1
+          fi


### PR DESCRIPTION
Resurrects the 18 strategy rows the queen-hive has been holding since 2026-05-15. The pull-loop scarab image expected a nonexistent 'claims' table, so all 18 services were spamming connection errors. This workflow swaps them onto the env-driven trainer-igla path that is already producing live data on the 7 SHORT-WAVE-MATRIX services.

For each row in ssot.scarab_strategy (status=active):
1. Look up project_id/env_id from .github/wave-a/*.csv
2. variableUpsert FORMAT / OPTIMIZER / HIDDEN_DIM / SEED / LR / STEPS / TRIOS_CANON_NAME / RAILWAY_POSTGRES_URL / L_R8_SYNTHETIC_FALLBACK=FORBID / RUST_LOG=info via Railway GraphQL
3. serviceInstanceDeployV2 to kick redeploy

Canon: IGLA-STRATEGY-{format}-h{hidden}-LR{lr}-rng{seed}-{optimizer}

Requires confirm=PHI; supports dry_run input.

Anchor: phi^2 + phi^-2 = 3 · TRINITY · NEVER STOP