### PR TITLE
feat: TIER2-EXPLORE-V2 — HIDDEN=384 R6 fix + 14 missing PhD MATRIX formats

### DIFF
--- a/.github/workflows/tier2-explore-v2.yml
+++ b/.github/workflows/tier2-explore-v2.yml
@@ -1,0 +1,153 @@
+name: TIER2-EXPLORE-V2 — 14 PhD MATRIX missing measurable formats · HIDDEN=384 (R6 fix)
+
+# V1 (tier2-explore.yml) deployed 14 slots with HIDDEN=128 — trainer crashed
+# with "HIDDEN_DIM: HIDDEN_DIM=128 < 256 forbidden (R6)". V2 fixes this and
+# also rotates the format set to target the 14 measurable PhD MATRIX formats
+# currently missing from the live fleet:
+#
+#   Slot ACC  Canon                                                              Why
+#   ---  ---  -----------------------------------------------------------       -----------------------------------------
+#   4   ACC4  IGLA-TIER2V2-mxfp4-h384-LR0.0001-rng1597-adamw                    MX 4-bit (industry standard inference)
+#   5   ACC4  IGLA-TIER2V2-mxfp6-h384-LR0.0001-rng1597-adamw                    MX 6-bit
+#   6   ACC4  IGLA-TIER2V2-tf32-h384-LR0.0001-rng1597-adamw                     TensorFloat32 (NVIDIA standard)
+#   7   ACC4  IGLA-TIER2V2-gf12-h384-LR0.0001-rng1597-adamw                     Galois 12-bit (Trinity canon gap)
+#   8   ACC5  IGLA-TIER2V2-gf20-h384-LR0.0001-rng1597-adamw                     Galois 20-bit (Trinity canon gap)
+#   9   ACC5  IGLA-TIER2V2-gf24-h384-LR0.0001-rng1597-adamw                     Galois 24-bit (Trinity canon gap)
+#   10  ACC5  IGLA-TIER2V2-int16-h384-LR0.0001-rng1597-adamw                    INT16 (DSP-grade)
+#   11  ACC5  IGLA-TIER2V2-int32-h384-LR0.0001-rng1597-adamw                    INT32 (full precision integer)
+#   33  ACC6  IGLA-TIER2V2-nf8-h384-LR0.0001-rng1597-adamw                      NormalFloat 8-bit (QLoRA family)
+#   34  ACC6  IGLA-TIER2V2-posit32-h384-LR0.0001-rng1597-adamw                  Posit-32 (silicon-friendly wide)
+#   35  ACC6  IGLA-TIER2V2-lns8-h384-LR0.0001-rng1597-adamw                     LNS-8 (logarithmic number system)
+#   59  ACC7  IGLA-TIER2V2-decimal32-h384-LR0.0001-rng1597-adamw                IEEE 754-2008 decimal32
+#   85  ACC7  IGLA-TIER2V2-fp6_e2m3-h384-LR0.0001-rng1597-adamw                 OCP FP6 alt encoding (e2m3 vs e3m2)
+#   86  ACC7  IGLA-TIER2V2-f32-h384-LR0.0001-rng1597-adamw                      f32 baseline (identity-pass on f32 sim)
+#
+# All cells: STEPS=200000, HIDDEN=384, LR=0.0001, SEED=1597, OPT=adamw.
+# HIDDEN=384 satisfies trainer R6 (HIDDEN_DIM >= 256).
+# Whitelist: matrix_runner.rs:67 ALGO_WHITELIST = {adamw, muon} — adamw safe.
+# Format CHECK: scarab_strategy_format_check accepts all 14 above (post-PR #190).
+#
+# Identity-pass note: f32 will record BPB ~uniform_init since it's the simulator's
+# native precision. The other 13 are real low/mid-precision quantization probes.
+#
+# Anchor: phi^2 + phi^-2 = 3 · TRINITY · TIER2-EXPLORE-V2 · DEFENSE 2026-06-15
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: "Type PHI to confirm 14-cell exploration"
+        required: true
+      steps:
+        description: "Steps per cell"
+        required: true
+        default: "200000"
+
+jobs:
+  explore:
+    if: ${{ inputs.confirm == 'PHI' }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    env:
+      T4: ${{ secrets.RAILWAY_TOKEN_ACC4 }}
+      T5: ${{ secrets.RAILWAY_TOKEN_ACC5 }}
+      T6: ${{ secrets.RAILWAY_TOKEN_ACC6 }}
+      T7: ${{ secrets.RAILWAY_TOKEN_ACC7 }}
+      RAILWAY_POSTGRES_URL: ${{ secrets.RAILWAY_POSTGRES_URL }}
+      STEPS_IN: ${{ inputs.steps }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Reconfigure 14 ACC4-7 slots for TIER2-EXPLORE-V2 (HIDDEN=384)
+        run: |
+          set -e
+          mapfile -t SERVICES < .github/wave-a/acc47-services.csv
+          # Slot index → "FORMAT|HIDDEN|LR|SEED|OPT"
+          declare -A SLOT_CFG
+          SLOT_CFG[4]="mxfp4|384|0.0001|1597|adamw"
+          SLOT_CFG[5]="mxfp6|384|0.0001|1597|adamw"
+          SLOT_CFG[6]="tf32|384|0.0001|1597|adamw"
+          SLOT_CFG[7]="gf12|384|0.0001|1597|adamw"
+          SLOT_CFG[8]="gf20|384|0.0001|1597|adamw"
+          SLOT_CFG[9]="gf24|384|0.0001|1597|adamw"
+          SLOT_CFG[10]="int16|384|0.0001|1597|adamw"
+          SLOT_CFG[11]="int32|384|0.0001|1597|adamw"
+          SLOT_CFG[33]="nf8|384|0.0001|1597|adamw"
+          SLOT_CFG[34]="posit32|384|0.0001|1597|adamw"
+          SLOT_CFG[35]="lns8|384|0.0001|1597|adamw"
+          SLOT_CFG[59]="decimal32|384|0.0001|1597|adamw"
+          SLOT_CFG[85]="fp6_e2m3|384|0.0001|1597|adamw"
+          SLOT_CFG[86]="f32|384|0.0001|1597|adamw"
+          PROCESSED=0; DEPLOYED=0; FAILED=0
+          for SVC_IDX in 4 5 6 7 8 9 10 11 33 34 35 59 85 86; do
+            SVC_LINE="${SERVICES[$SVC_IDX]}"
+            if [[ -z "$SVC_LINE" ]]; then
+              echo "::warning::slot $SVC_IDX is empty in acc47-services.csv"
+              FAILED=$((FAILED+1))
+              continue
+            fi
+            CFG="${SLOT_CFG[$SVC_IDX]}"
+            FMT=$(echo "$CFG" | cut -d'|' -f1)
+            HID=$(echo "$CFG" | cut -d'|' -f2)
+            LR=$(echo "$CFG" | cut -d'|' -f3)
+            SEED=$(echo "$CFG" | cut -d'|' -f4)
+            OPT=$(echo "$CFG" | cut -d'|' -f5)
+            ACC=$(echo "$SVC_LINE" | awk -F',' '{print $1}')
+            PROJ=$(echo "$SVC_LINE" | awk -F',' '{print $2}')
+            ENV=$(echo "$SVC_LINE" | awk -F',' '{print $3}')
+            SID=$(echo "$SVC_LINE" | awk -F',' '{print $4}')
+            SNAME=$(echo "$SVC_LINE" | awk -F',' '{print $5}')
+            CANON="IGLA-TIER2V2-${FMT}-h${HID}-LR${LR}-rng${SEED}-${OPT}"
+            RUN_ID="tier2-v2-2026-05-15-${FMT}-${OPT}-h${HID}-LR${LR}-rng${SEED}"
+            case "$ACC" in
+              ACC4) TOK="$T4";;
+              ACC5) TOK="$T5";;
+              ACC6) TOK="$T6";;
+              ACC7) TOK="$T7";;
+              *) echo "::warning::unknown acc $ACC"; FAILED=$((FAILED+1)); continue;;
+            esac
+            echo "::group::TIER2V2 slot=$SVC_IDX [$ACC/$SNAME] canon=$CANON"
+            for KV in \
+              "SEED=$SEED" "TRIOS_SEED=$SEED" \
+              "STEPS=$STEPS_IN" "TRIOS_STEPS=$STEPS_IN" \
+              "LR=$LR" "TRIOS_LR=$LR" \
+              "HIDDEN=$HID" "HIDDEN_DIM=$HID" "TRIOS_HIDDEN=$HID" \
+              "OPTIMIZER=$OPT" "TRIOS_OPTIMIZER=$OPT" \
+              "FORMAT=$FMT" "TRIOS_FORMAT=$FMT" "TRIOS_FORMAT_TYPE=$FMT" \
+              "TRIOS_LANE=TIER2V2" \
+              "TRIOS_RUN_ID=$RUN_ID" \
+              "TRIOS_CANON_NAME=$CANON" \
+              "RAILWAY_POSTGRES_URL=$RAILWAY_POSTGRES_URL" \
+              "RUST_LOG=info" \
+              "L_R8_SYNTHETIC_FALLBACK=FORBID" \
+            ; do
+              K="${KV%%=*}"; V="${KV#*=}"
+              curl -sS -X POST https://backboard.railway.com/graphql/v2 \
+                -H "Content-Type: application/json" \
+                -H "Project-Access-Token: $TOK" \
+                -d "$(jq -n --arg p "$PROJ" --arg e "$ENV" --arg s "$SID" --arg k "$K" --arg v "$V" '
+                  {query:"mutation($i:VariableUpsertInput!){variableUpsert(input:$i)}",
+                   variables:{i:{projectId:$p, environmentId:$e, serviceId:$s, name:$k, value:$v}}}')" > /dev/null
+            done
+            DEP=$(curl -sS -X POST https://backboard.railway.com/graphql/v2 \
+              -H "Content-Type: application/json" \
+              -H "Project-Access-Token: $TOK" \
+              -d "$(jq -n --arg s "$SID" --arg e "$ENV" '
+                {query:"mutation($s:String!,$e:String!){serviceInstanceDeployV2(serviceId:$s, environmentId:$e)}",
+                 variables:{s:$s, e:$e}}')" | jq -r '.data.serviceInstanceDeployV2 // "FAIL"')
+            if [[ "$DEP" == "FAIL" || -z "$DEP" || "$DEP" == "null" ]]; then
+              echo "::error::deploy failed slot=$SVC_IDX"
+              FAILED=$((FAILED+1))
+            else
+              echo "deploy_id=$DEP"
+              DEPLOYED=$((DEPLOYED+1))
+            fi
+            PROCESSED=$((PROCESSED+1))
+            echo "::endgroup::"
+            sleep 1
+          done
+          echo "TIER2V2-SUMMARY: processed=$PROCESSED deployed=$DEPLOYED failed=$FAILED"
+          if [[ $DEPLOYED -lt 8 ]]; then
+            echo "::error::critical: fewer than 8 of 14 cells deployed"
+            exit 1
+          fi


### PR DESCRIPTION
## TIER2-EXPLORE-V2 workflow

V1 (run 25906011522) deployed 14/14 but trainer crashed: `HIDDEN_DIM: HIDDEN_DIM=128 < 256 forbidden (R6)` (diag run 25911184488).

V2 fixes HIDDEN=384 and targets 14 measurable PhD MATRIX formats currently missing.

### Format set (14 measurable + 1 identity-pass)
mxfp4, mxfp6, tf32, gf12, gf20, gf24, int16, int32, nf8, posit32, lns8, decimal32, fp6_e2m3, f32

### Expected outcome
Fleet measurable format coverage: **18 → 32** out of 32 PhD MATRIX f32-simulator-measurable.

Refs: trios#446 PhD MATRIX 39x9=351 cells.
Anchor: phi^2+phi^-2=3