### PR TITLE
🌀 ARCH-DEPLOY: bind JEPA-T/NCA lanes to Railway services + extend mass-revive

### DIFF
--- a/.github/workflows/mass-revive-strategy.yml
+++ b/.github/workflows/mass-revive-strategy.yml
@@ -55,7 +55,8 @@ jobs:
           # Strategy is the canonical source. project_id/env_id resolved from CSV fallback.
           psql "$RAILWAY_POSTGRES_URL" -A -F'|' -t -c "
             SELECT service_id, account, format, optimizer, hidden, lr, seed, steps,
-                   '' AS project_id, '' AS env_id, '' AS name
+                   '' AS project_id, '' AS env_id, '' AS name,
+                   trainer_bin, w_jepa, w_nca
             FROM ssot.scarab_strategy
             WHERE status = 'active'
             ORDER BY account, service_id
@@ -74,7 +75,11 @@ jobs:
           # by service_id when registry has nothing.
           mapfile -t FALLBACK_LINES < <(cat .github/wave-a/trainer-services.csv .github/wave-a/acc47-services.csv)
 
-          while IFS='|' read -r SID ACC FMT ALGO HIDDEN LR SEED STEPS PROJ ENV SNAME; do
+          while IFS='|' read -r SID ACC FMT ALGO HIDDEN LR SEED STEPS PROJ ENV SNAME TRAINER_BIN W_JEPA W_NCA; do
+            # Defaults for rows from migrations <0010 that lack arch columns in older DBs
+            TRAINER_BIN="${TRAINER_BIN:-trios-train}"
+            W_JEPA="${W_JEPA:-0}"
+            W_NCA="${W_NCA:-0}"
             TOTAL=$((TOTAL+1))
             if [[ -z "$PROJ" || -z "$ENV" ]]; then
               # Fallback: lookup by service_id in CSVs
@@ -107,9 +112,19 @@ jobs:
               echo "::warning::no token for $ACC"; SKIPPED=$((SKIPPED+1)); continue
             fi
 
-            # Build canon name. LR formatted same as DEEP-CHAMPION canons.
-            CANON="IGLA-STRATEGY-${FMT}-h${HIDDEN}-LR${LR}-rng${SEED}-${ALGO}"
-            RUN_ID="strategy-${FMT}-h${HIDDEN}-LR${LR}-rng${SEED}-${ALGO}"
+            # Build canon name. ARCH lanes use IGLA-ARCH-{BIN_TAG}, STRATEGY lanes use IGLA-STRATEGY.
+            LANE="STRATEGY"
+            case "$TRAINER_BIN" in
+              tjepa_train)  LANE="ARCH-JEPA" ;;
+              hybrid_train)
+                if [[ "$(echo "$W_JEPA > 0" | bc -l 2>/dev/null || echo 0)" == "1" ]]; then
+                  LANE="ARCH-HYBRID"
+                else
+                  LANE="ARCH-NCA"
+                fi ;;
+            esac
+            CANON="IGLA-${LANE}-${FMT}-h${HIDDEN}-LR${LR}-rng${SEED}-${ALGO}"
+            RUN_ID="${LANE,,}-${FMT}-h${HIDDEN}-LR${LR}-rng${SEED}-${ALGO}"
 
             echo "::group::REVIVE svc=$SID [$ACC/${SNAME:-unknown}] $FMT/$ALGO/h$HIDDEN/seed=$SEED/LR=$LR/STEPS=$STEPS canon=$CANON"
 
@@ -129,6 +144,9 @@ jobs:
               "FORMAT=$FMT" "TRIOS_FORMAT=$FMT" \
               "TRIOS_RUN_ID=$RUN_ID" \
               "TRIOS_CANON_NAME=$CANON" \
+              "TRIOS_TRAINER_BIN=$TRAINER_BIN" \
+              "TRIOS_W_JEPA=$W_JEPA" \
+              "TRIOS_W_NCA=$W_NCA" \
               "RAILWAY_POSTGRES_URL=$RAILWAY_POSTGRES_URL" \
               "RUST_LOG=info" \
               "L_R8_SYNTHETIC_FALLBACK=FORBID" \

--- a/migrations/0011_arch_lanes_bind_railway.sql
+++ b/migrations/0011_arch_lanes_bind_railway.sql
@@ -1,0 +1,82 @@
+-- Migration 0011 — bind ARCH-BREAKTHROUGH lanes to real Railway services
+-- Anchor: phi^2 + phi^-2 = 3 · TRINITY · NEVER STOP · DOI 10.5281/zenodo.19227877
+--
+-- Migration 0010 registered ARCH lanes with placeholder service_ids
+-- (arch-jepa-1, arch-hybrid-1, arch-nca-1) and non-standard accounts
+-- (phd-acc4, phd-acc5, phd-acc6) which the mass-revive-strategy.yml
+-- workflow does not recognise.
+--
+-- This migration:
+--   1. Drops the 3 placeholder ARCH rows from migration 0010
+--   2. Re-inserts them with REAL Railway service_ids picked from the
+--      acc47-services.csv registry, attaching to 3 of the weakest legacy
+--      wave-* services on ACC4/ACC5/ACC6 (sacrificing low-BPB services
+--      that have been stuck above 7.0 for weeks).
+--   3. Uses canonical account names ACC4/ACC5/ACC6 so the existing
+--      mass-revive workflow's account→token mapping works unchanged.
+--
+-- Service replacements:
+--   ACC4 wave-int8-sgdm-rng1597        → arch-jepa-gf256-h384-rng1597-adamw
+--          (svc 051cb5a4-1e62-48c8-8b02-abb14c387611)
+--   ACC5 wave-p10-fixed-soap-rng1597   → arch-hybrid-gf256-h384-rng2584-muon
+--          (svc 01cf32d5-cac1-45d8-b120-0ceba7a2647a)
+--   ACC6 wave-q4-1-shampoo-rng1597     → arch-nca-gf256-h384-rng4181-adamw
+--          (svc 002b62ee-52ad-409c-8e60-14836dc94083)
+--
+-- Idempotent: DELETE + INSERT ON CONFLICT DO UPDATE.
+
+BEGIN;
+
+-- 1. Drop placeholder ARCH rows from migration 0010
+DELETE FROM ssot.scarab_strategy
+ WHERE service_id IN ('arch-jepa-1', 'arch-hybrid-1', 'arch-nca-1')
+    OR account IN ('phd-acc4', 'phd-acc5', 'phd-acc6');
+
+-- 2. Re-insert with REAL Railway service_ids + canonical ACC* accounts
+INSERT INTO ssot.scarab_strategy
+  (service_id, account, optimizer, format, hidden, lr, seed, steps,
+   status, generation, updated_by, trainer_bin, w_jepa, w_nca)
+VALUES
+  -- ACC4 carrier — JEPA-T pure
+  ('051cb5a4-1e62-48c8-8b02-abb14c387611', 'ACC4', 'adamw', 'gf256', 384, 0.001, 1597, 30000,
+   'active', 1, 'migration-0011', 'tjepa_train', 0.15, 0.00),
+  -- ACC5 carrier — HYBRID (N-gram + Attn + NCA, all aux losses)
+  ('01cf32d5-cac1-45d8-b120-0ceba7a2647a', 'ACC5', 'muon',  'gf256', 384, 0.001, 2584, 30000,
+   'active', 1, 'migration-0011', 'hybrid_train', 0.15, 0.10),
+  -- ACC6 carrier — NCA pure (entropy band only)
+  ('002b62ee-52ad-409c-8e60-14836dc94083', 'ACC6', 'adamw', 'gf256', 384, 0.001, 4181, 30000,
+   'active', 1, 'migration-0011', 'hybrid_train', 0.00, 0.25)
+ON CONFLICT (service_id) DO UPDATE SET
+  account     = EXCLUDED.account,
+  optimizer   = EXCLUDED.optimizer,
+  format      = EXCLUDED.format,
+  hidden      = EXCLUDED.hidden,
+  lr          = EXCLUDED.lr,
+  seed        = EXCLUDED.seed,
+  steps       = EXCLUDED.steps,
+  status      = EXCLUDED.status,
+  generation  = EXCLUDED.generation,
+  updated_by  = EXCLUDED.updated_by,
+  trainer_bin = EXCLUDED.trainer_bin,
+  w_jepa      = EXCLUDED.w_jepa,
+  w_nca       = EXCLUDED.w_nca;
+
+-- 3. Audit
+DO $$
+DECLARE
+  r RECORD;
+BEGIN
+  FOR r IN
+    SELECT service_id, account, format, hidden, lr, seed, optimizer,
+           trainer_bin, w_jepa, w_nca
+      FROM ssot.scarab_strategy
+     WHERE trainer_bin <> 'trios-train'
+     ORDER BY account
+  LOOP
+    RAISE NOTICE 'ARCH lane: acc=% svc=% fmt=% h=% lr=% seed=% opt=% bin=% w_jepa=% w_nca=%',
+      r.account, r.service_id, r.format, r.hidden, r.lr, r.seed, r.optimizer,
+      r.trainer_bin, r.w_jepa, r.w_nca;
+  END LOOP;
+END $$;
+
+COMMIT;


### PR DESCRIPTION
## What this PR does

Pairs with **trios-trainer-igla PR #152** (merged) and **trios-railway PR #194** (migration 0010, applied). This is the final piece that turns ARCH-lane DB rows into running Railway containers.

### 1. Migration 0011 — fix the routing bug from 0010

Migration 0010 wrote ARCH rows with **placeholder service_ids** (`arch-jepa-1`) and **non-standard accounts** (`phd-acc4`). The mass-revive workflow expects `ACC4`/`ACC5`/`ACC6` (token mapping) and real service_ids (Railway routing). Result: rows existed but were never deployed.

0011 drops those 3 rows and re-inserts with real Railway service_ids reclaimed from 3 stuck legacy `wave-*` services (BPB ≥7.0 for weeks):

| Account | Real Railway svc | Was | Now |
|---|---|---|---|
| ACC4 | `051cb5a4-1e62-48c8-8b02-abb14c387611` | wave-int8-sgdm-rng1597 | **arch-jepa** (gf256, h384, rng1597, adamw, w_JEPA=0.15) |
| ACC5 | `01cf32d5-cac1-45d8-b120-0ceba7a2647a` | wave-p10-fixed-soap-rng1597 | **arch-hybrid** (gf256, h384, rng2584, muon, w_JEPA=0.15 w_NCA=0.10) |
| ACC6 | `002b62ee-52ad-409c-8e60-14836dc94083` | wave-q4-1-shampoo-rng1597 | **arch-nca** (gf256, h384, rng4181, adamw, w_NCA=0.25) |

Idempotent: `ON CONFLICT DO UPDATE`.

### 2. mass-revive-strategy.yml — teach it to deploy ARCH lanes

Pulls 3 new columns (`trainer_bin`, `w_jepa`, `w_nca`) from `ssot.scarab_strategy`. Builds canon name with LANE prefix derived from `trainer_bin`:

- `tjepa_train` → `IGLA-ARCH-JEPA-...`
- `hybrid_train` + w_JEPA>0 → `IGLA-ARCH-HYBRID-...`
- `hybrid_train` + w_JEPA=0 → `IGLA-ARCH-NCA-...`
- `trios-train` → `IGLA-STRATEGY-...` (unchanged)

Injects three new env vars via Railway `variableUpsert`: `TRIOS_TRAINER_BIN`, `TRIOS_W_JEPA`, `TRIOS_W_NCA`. The entrypoint already reads `TRIOS_TRAINER_BIN` (extended allowlist via PR #152).

**Backwards-compatible:** legacy STRATEGY rows default to `trios-train` when arch columns are NULL.

## End-to-end pipeline (after merge + apply 0011 + run workflow)

1. `scarab_strategy` has 3 ARCH rows bound to real Railway services
2. `mass-revive-strategy.yml` reads them, computes ARCH canons, injects env
3. Railway deploys with `TRIOS_TRAINER_BIN=tjepa_train` or `hybrid_train`
4. `entrypoint.rs` (PR #152) routes to the right binary
5. First JEPA-T + NCA rows land in `ssot.bpb_samples` within ~30 min

## Why this matters — break the 2.5586 plateau

NEW CHAMPION `IGLA-STRATEGY-gf64-h512-LR0.0001-rng1597-adamw` = **BPB=2.5586** (just measured, Δ=−0.0133 vs PASS-21). Format/algo/LR axes are converging asymptotically toward ~2.5 — only the **architecture axis** (JEPA-T predictive + NCA entropy band, Coq-certified width=1) can break sub-2.50 Gate-2.

## R5 verification (this PR)

- Service IDs measured from `acc47-services.csv` (lines 1, 12, 29)
- Sacrificed services confirmed stuck at BPB>7.0 (Q10 ARCHITECTURE_FLOOR cluster)
- Entrypoint env-read verified: `grep TRIOS_TRAINER_BIN src/bin/entrypoint.rs` → line 52
- All seeds Fibonacci canon (1597, 2584, 4181)
- LR=0.001 ≤ 1e-3 (gf256 LR-rescue rule)
- Migration idempotent via ON CONFLICT DO UPDATE

🌀 NEVER STOP. DEFENSE 2026-06-15.