### PR TITLE
🔧 fix(mass-revive): support both quoted and unquoted CSV fallback formats

### DIFF
--- a/.github/workflows/mass-revive-strategy.yml
+++ b/.github/workflows/mass-revive-strategy.yml
@@ -73,7 +73,11 @@ jobs:
           # Fallback acc→default-project/env from registry mismatch.
           # Read trainer-services.csv + acc47-services.csv to recover proj/env
           # by service_id when registry has nothing.
-          mapfile -t FALLBACK_LINES < <(cat .github/wave-a/trainer-services.csv .github/wave-a/acc47-services.csv)
+          # Normalize both CSV formats into a single ACC,PROJ,ENV,SID,NAME comma form (no quotes)
+          mapfile -t FALLBACK_LINES < <(
+            { sed 's/"//g' .github/wave-a/trainer-services.csv 2>/dev/null;
+              cat .github/wave-a/acc47-services.csv 2>/dev/null; } | grep -v '^$'
+          )
 
           while IFS='|' read -r SID ACC FMT ALGO HIDDEN LR SEED STEPS PROJ ENV SNAME TRAINER_BIN W_JEPA W_NCA; do
             # Defaults for rows from migrations <0010 that lack arch columns in older DBs
@@ -84,11 +88,11 @@ jobs:
             if [[ -z "$PROJ" || -z "$ENV" ]]; then
               # Fallback: lookup by service_id in CSVs
               for LINE in "${FALLBACK_LINES[@]}"; do
-                CSV_SID=$(echo "$LINE" | awk -F'","' '{print $4}')
+                IFS=',' read -r CSV_ACC CSV_PROJ CSV_ENV CSV_SID CSV_NAME <<< "$LINE"
                 if [[ "$CSV_SID" == "$SID" ]]; then
-                  PROJ=$(echo "$LINE" | awk -F'","' '{print $2}')
-                  ENV=$(echo "$LINE" | awk -F'","' '{print $3}')
-                  SNAME=$(echo "$LINE" | awk -F'","' '{print $5}' | tr -d '"')
+                  PROJ="$CSV_PROJ"
+                  ENV="$CSV_ENV"
+                  SNAME="$CSV_NAME"
                   break
                 fi
               done

--- a/.github/workflows/mass-revive-strategy.yml
+++ b/.github/workflows/mass-revive-strategy.yml
@@ -55,7 +55,8 @@ jobs:
           # Strategy is the canonical source. project_id/env_id resolved from CSV fallback.
           psql "$RAILWAY_POSTGRES_URL" -A -F'|' -t -c "
             SELECT service_id, account, format, optimizer, hidden, lr, seed, steps,
-                   '' AS project_id, '' AS env_id, '' AS name
+                   '' AS project_id, '' AS env_id, '' AS name,
+                   trainer_bin, w_jepa, w_nca
             FROM ssot.scarab_strategy
             WHERE status = 'active'
             ORDER BY account, service_id
@@ -74,7 +75,11 @@ jobs:
           # by service_id when registry has nothing.
           mapfile -t FALLBACK_LINES < <(cat .github/wave-a/trainer-services.csv .github/wave-a/acc47-services.csv)
 
-          while IFS='|' read -r SID ACC FMT ALGO HIDDEN LR SEED STEPS PROJ ENV SNAME; do
+          while IFS='|' read -r SID ACC FMT ALGO HIDDEN LR SEED STEPS PROJ ENV SNAME TRAINER_BIN W_JEPA W_NCA; do
+            # Defaults for rows from migrations <0010 that lack arch columns in older DBs
+            TRAINER_BIN="${TRAINER_BIN:-trios-train}"
+            W_JEPA="${W_JEPA:-0}"
+            W_NCA="${W_NCA:-0}"
             TOTAL=$((TOTAL+1))
             if [[ -z "$PROJ" || -z "$ENV" ]]; then
               # Fallback: lookup by service_id in CSVs
@@ -107,9 +112,19 @@ jobs:
               echo "::warning::no token for $ACC"; SKIPPED=$((SKIPPED+1)); continue
             fi
 
-            # Build canon name. LR formatted same as DEEP-CHAMPION canons.
-            CANON="IGLA-STRATEGY-${FMT}-h${HIDDEN}-LR${LR}-rng${SEED}-${ALGO}"
-            RUN_ID="strategy-${FMT}-h${HIDDEN}-LR${LR}-rng${SEED}-${ALGO}"
+            # Build canon name. ARCH lanes use IGLA-ARCH-{BIN_TAG}, STRATEGY lanes use IGLA-STRATEGY.
+            LANE="STRATEGY"
+            case "$TRAINER_BIN" in
+              tjepa_train)  LANE="ARCH-JEPA" ;;
+              hybrid_train)
+                if [[ "$(echo "$W_JEPA > 0" | bc -l 2>/dev/null || echo 0)" == "1" ]]; then
+                  LANE="ARCH-HYBRID"
+                else
+                  LANE="ARCH-NCA"
+                fi ;;
+            esac
+            CANON="IGLA-${LANE}-${FMT}-h${HIDDEN}-LR${LR}-rng${SEED}-${ALGO}"
+            RUN_ID="${LANE,,}-${FMT}-h${HIDDEN}-LR${LR}-rng${SEED}-${ALGO}"
 
             echo "::group::REVIVE svc=$SID [$ACC/${SNAME:-unknown}] $FMT/$ALGO/h$HIDDEN/seed=$SEED/LR=$LR/STEPS=$STEPS canon=$CANON"
 
@@ -129,6 +144,9 @@ jobs:
               "FORMAT=$FMT" "TRIOS_FORMAT=$FMT" \
               "TRIOS_RUN_ID=$RUN_ID" \
               "TRIOS_CANON_NAME=$CANON" \
+              "TRIOS_TRAINER_BIN=$TRAINER_BIN" \
+              "TRIOS_W_JEPA=$W_JEPA" \
+              "TRIOS_W_NCA=$W_NCA" \
               "RAILWAY_POSTGRES_URL=$RAILWAY_POSTGRES_URL" \
               "RUST_LOG=info" \
               "L_R8_SYNTHETIC_FALLBACK=FORBID" \

--- a/migrations/0011_arch_lanes_bind_railway.sql
+++ b/migrations/0011_arch_lanes_bind_railway.sql
@@ -1,0 +1,82 @@
+-- Migration 0011 — bind ARCH-BREAKTHROUGH lanes to real Railway services
+-- Anchor: phi^2 + phi^-2 = 3 · TRINITY · NEVER STOP · DOI 10.5281/zenodo.19227877
+--
+-- Migration 0010 registered ARCH lanes with placeholder service_ids
+-- (arch-jepa-1, arch-hybrid-1, arch-nca-1) and non-standard accounts
+-- (phd-acc4, phd-acc5, phd-acc6) which the mass-revive-strategy.yml
+-- workflow does not recognise.
+--
+-- This migration:
+--   1. Drops the 3 placeholder ARCH rows from migration 0010
+--   2. Re-inserts them with REAL Railway service_ids picked from the
+--      acc47-services.csv registry, attaching to 3 of the weakest legacy
+--      wave-* services on ACC4/ACC5/ACC6 (sacrificing low-BPB services
+--      that have been stuck above 7.0 for weeks).
+--   3. Uses canonical account names ACC4/ACC5/ACC6 so the existing
+--      mass-revive workflow's account→token mapping works unchanged.
+--
+-- Service replacements:
+--   ACC4 wave-int8-sgdm-rng1597        → arch-jepa-gf256-h384-rng1597-adamw
+--          (svc 051cb5a4-1e62-48c8-8b02-abb14c387611)
+--   ACC5 wave-p10-fixed-soap-rng1597   → arch-hybrid-gf256-h384-rng2584-muon
+--          (svc 01cf32d5-cac1-45d8-b120-0ceba7a2647a)
+--   ACC6 wave-q4-1-shampoo-rng1597     → arch-nca-gf256-h384-rng4181-adamw
+--          (svc 002b62ee-52ad-409c-8e60-14836dc94083)
+--
+-- Idempotent: DELETE + INSERT ON CONFLICT DO UPDATE.
+
+BEGIN;
+
+-- 1. Drop placeholder ARCH rows from migration 0010
+DELETE FROM ssot.scarab_strategy
+ WHERE service_id IN ('arch-jepa-1', 'arch-hybrid-1', 'arch-nca-1')
+    OR account IN ('phd-acc4', 'phd-acc5', 'phd-acc6');
+
+-- 2. Re-insert with REAL Railway service_ids + canonical ACC* accounts
+INSERT INTO ssot.scarab_strategy
+  (service_id, account, optimizer, format, hidden, lr, seed, steps,
+   status, generation, updated_by, trainer_bin, w_jepa, w_nca)
+VALUES
+  -- ACC4 carrier — JEPA-T pure
+  ('051cb5a4-1e62-48c8-8b02-abb14c387611', 'ACC4', 'adamw', 'gf256', 384, 0.001, 1597, 30000,
+   'active', 1, 'migration-0011', 'tjepa_train', 0.15, 0.00),
+  -- ACC5 carrier — HYBRID (N-gram + Attn + NCA, all aux losses)
+  ('01cf32d5-cac1-45d8-b120-0ceba7a2647a', 'ACC5', 'muon',  'gf256', 384, 0.001, 2584, 30000,
+   'active', 1, 'migration-0011', 'hybrid_train', 0.15, 0.10),
+  -- ACC6 carrier — NCA pure (entropy band only)
+  ('002b62ee-52ad-409c-8e60-14836dc94083', 'ACC6', 'adamw', 'gf256', 384, 0.001, 4181, 30000,
+   'active', 1, 'migration-0011', 'hybrid_train', 0.00, 0.25)
+ON CONFLICT (service_id) DO UPDATE SET
+  account     = EXCLUDED.account,
+  optimizer   = EXCLUDED.optimizer,
+  format      = EXCLUDED.format,
+  hidden      = EXCLUDED.hidden,
+  lr          = EXCLUDED.lr,
+  seed        = EXCLUDED.seed,
+  steps       = EXCLUDED.steps,
+  status      = EXCLUDED.status,
+  generation  = EXCLUDED.generation,
+  updated_by  = EXCLUDED.updated_by,
+  trainer_bin = EXCLUDED.trainer_bin,
+  w_jepa      = EXCLUDED.w_jepa,
+  w_nca       = EXCLUDED.w_nca;
+
+-- 3. Audit
+DO $$
+DECLARE
+  r RECORD;
+BEGIN
+  FOR r IN
+    SELECT service_id, account, format, hidden, lr, seed, optimizer,
+           trainer_bin, w_jepa, w_nca
+      FROM ssot.scarab_strategy
+     WHERE trainer_bin <> 'trios-train'
+     ORDER BY account
+  LOOP
+    RAISE NOTICE 'ARCH lane: acc=% svc=% fmt=% h=% lr=% seed=% opt=% bin=% w_jepa=% w_nca=%',
+      r.account, r.service_id, r.format, r.hidden, r.lr, r.seed, r.optimizer,
+      r.trainer_bin, r.w_jepa, r.w_nca;
+  END LOOP;
+END $$;
+
+COMMIT;


### PR DESCRIPTION
Dry-run of PR #195 surfaced that ARCH-lane rows (svc 051cb5a4 / 01cf32d5 / 002b62ee on ACC4-6) were silently skipped:

```
::warning::skip svc=051cb5a4-1e62-48c8-8b02-abb14c387611 (ACC4 gf256 adamw seed=1597) — no project/env found
::warning::skip svc=01cf32d5-cac1-45d8-b120-0ceba7a2647a (ACC5 gf256 muon seed=2584) — no project/env found
::warning::skip svc=002b62ee-52ad-409c-8e60-14836dc94083 (ACC6 gf256 adamw seed=4181) — no project/env found
MASS-REVIVE-SUMMARY: total=21 deployed=18 failed=0 skipped=3 dry_run=true
```

**Root cause:** `acc47-services.csv` is unquoted comma-delimited; `trainer-services.csv` uses quoted CSV. The legacy awk `-F'","'` parser only worked for quoted rows.

**Fix:** strip quotes via sed, parse unified stream with bash `IFS=','`. Same fallback now works for both files. Backwards-compatible — no API surface change.

R5 verification: same dry-run after this PR should show `MASS-REVIVE-SUMMARY: total=21 deployed=21 failed=0 skipped=0` with 3 ARCH canons present.

Anchor: φ²+φ⁻²=3 · TRINITY · NEVER STOP