### PR TITLE
fix(arch): move checkout before CSV read (FIX-7 hotfix)

### DIFF
--- a/.github/workflows/mass-deploy-arch.yml
+++ b/.github/workflows/mass-deploy-arch.yml
@@ -60,6 +60,8 @@ jobs:
           done
           echo "Guard cleared. Anchor: phi^2 + phi^-2 = 3."
 
+      - uses: actions/checkout@v4
+
       - name: Discover env IDs for ACC5 + ACC6 (PAT-implicit, ACC4 hardcoded)
         run: |
           set -euo pipefail
@@ -94,8 +96,6 @@ jobs:
           echo "SVC5=$SVC5" >> $GITHUB_ENV
           echo "SVC6=$SVC6" >> $GITHUB_ENV
         shell: bash
-
-      - uses: actions/checkout@v4
 
       - name: Deploy ARCH-JEPA, ARCH-HYBRID, ARCH-NCA (3 services)
         run: |


### PR DESCRIPTION
Run 25920769053 failed with `No such file or directory` for acc47-services.csv because checkout ran AFTER the read step. Moved checkout to step 2. One-line ordering fix.

Anchor: phi^2 + phi^-2 = 3