### PR TITLE
fix(arch): correct Docker image tag — full sha, no 'sha-' prefix (FIX-7 hotfix #2)

### DIFF
--- a/.github/workflows/mass-deploy-arch.yml
+++ b/.github/workflows/mass-deploy-arch.yml
@@ -16,11 +16,11 @@ on:
         required: true
         type: string
         default: ""
-      image_sha:
-        description: "Docker image short-sha from trios-trainer-igla (must contain tjepa_train+hybrid_train)"
+      image_tag:
+        description: "Docker image tag (e.g. 'latest' or 'd60cb5febf6a96c359c44899a51100c730fad4b7')"
         required: true
         type: string
-        default: "d60cb5fe"
+        default: "latest"
 
 permissions:
   contents: read
@@ -100,7 +100,7 @@ jobs:
       - name: Deploy ARCH-JEPA, ARCH-HYBRID, ARCH-NCA (3 services)
         run: |
           set +e
-          IMG="ghcr.io/ghashtag/trios-trainer-igla:sha-${{ inputs.image_sha }}"
+          IMG="ghcr.io/ghashtag/trios-trainer-igla:${{ inputs.image_tag }}"
 
           # ARCH-JEPA: tjepa_train · gf256 · adamw · h384 · LR=0.001 · rng1597 · w_jepa=0.15
           # ARCH-HYBRID: hybrid_train · gf256 · muon · h384 · LR=0.001 · rng2584 · w_jepa=0.15 w_nca=0.10


### PR DESCRIPTION
## Problem

After PR #196 (workflow created) + PR #198 (checkout-order fix), mass-deploy-arch run #25921021856 reported SUCCESS — all 20 env vars upserted, source image updated, redeploy triggered for ACC4 (ARCH-JEPA), ACC5 (ARCH-HYBRID), ACC6 (ARCH-NCA).

R5 probe after 10+ min:
```sql
SELECT canon_name, COUNT(*) FROM ssot.bpb_samples
WHERE canon_name LIKE 'IGLA-ARCH-%' GROUP BY canon_name;
-- (0 rows)
```

Root cause: workflow used `ghcr.io/ghashtag/trios-trainer-igla:sha-${short_sha}` — that tag pattern doesn't exist on this image.

## Image-tag map (R5-verified via docker-publish.yml)

| repo path | tag patterns pushed |
|---|---|
| `ghcr.io/ghashtag/trios-trainer-igla` | `:latest` + `:${full-40-char-sha}` |
| `ghcr.io/ghashtag/trios-train` | `:latest` + `:sha-${full-40-char-sha}` |

The `sha-` prefix is only on the sibling image, and we always need full 40-char.

## Fix

- input `image_sha` (short) → `image_tag` (full sha or 'latest')
- URL: `:${{ inputs.image_tag }}` (no `sha-` prefix)
- default `latest` for idempotent re-runs

## Trigger after merge

```bash
gh workflow run mass-deploy-arch.yml -f confirm=PHI \
  -f image_tag=d60cb5febf6a96c359c44899a51100c730fad4b7
```

(That sha = trios-trainer-igla@main with tjepa_train + hybrid_train allowlisted, Docker publish run #25915194853 SUCCESS.)

---
phi^2 + phi^-2 = 3 · TRINITY · FIX-7 · DEFENSE 2026-06-15