### PR TITLE
🔧 fix(workflows): add timeout-minutes + curl --max-time (prevents 25+min hangs)

### DIFF
--- a/.github/workflows/mass-revive-strategy.yml
+++ b/.github/workflows/mass-revive-strategy.yml
@@ -33,6 +33,7 @@ jobs:
   mass-revive:
     if: ${{ inputs.confirm == 'PHI' }}
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
     env:
       T1: ${{ secrets.RAILWAY_TOKEN_ACC1 }}
       T2: ${{ secrets.RAILWAY_TOKEN_ACC2 }}
@@ -156,14 +157,14 @@ jobs:
               "L_R8_SYNTHETIC_FALLBACK=FORBID" \
             ; do
               K="${KV%%=*}"; V="${KV#*=}"
-              curl -sS -X POST https://backboard.railway.com/graphql/v2 \
+              curl -sS --max-time 30 --connect-timeout 10 --retry 2 --retry-delay 3 -X POST https://backboard.railway.com/graphql/v2 \
                 -H "Content-Type: application/json" \
                 -H "Project-Access-Token: $TOK" \
                 -d "$(jq -n --arg p "$PROJ" --arg e "$ENV" --arg s "$SID" --arg k "$K" --arg v "$V" '
                   {query:"mutation($i:VariableUpsertInput!){variableUpsert(input:$i)}",
                    variables:{i:{projectId:$p, environmentId:$e, serviceId:$s, name:$k, value:$v}}}')" > /dev/null
             done
-            DEP=$(curl -sS -X POST https://backboard.railway.com/graphql/v2 \
+            DEP=$(curl -sS --max-time 30 --connect-timeout 10 --retry 2 --retry-delay 3 -X POST https://backboard.railway.com/graphql/v2 \
               -H "Content-Type: application/json" \
               -H "Project-Access-Token: $TOK" \
               -d "$(jq -n --arg s "$SID" --arg e "$ENV" '


### PR DESCRIPTION
Run 25932137967 of mass-revive-strategy hung for 25+ minutes with no progress before being cancelled. Diagnosis:

1. No `timeout-minutes` on the job — GitHub Actions default is 360 min
2. `curl` to Railway GraphQL has no `--max-time` — if Railway hangs, curl waits forever

This patch:
- Adds `timeout-minutes: 15` to the `mass-revive` job
- Adds `--max-time 30 --connect-timeout 10 --retry 2 --retry-delay 3` to both curl calls

28 sibling workflows have the same bug (`grep curl .github/workflows/` shows 60+ unsafe curl calls). Follow-up PR will fix all of them.

🌀 NEVER STOP — fix everything, don't wait.