### PR TITLE
🔧 fix(kill-stale-waves v2): numReplicas=0 + deploymentCancel

### DIFF
--- a/.github/workflows/kill-stale-waves.yml
+++ b/.github/workflows/kill-stale-waves.yml
@@ -1,16 +1,10 @@
 name: KILL-STALE-WAVES — free deployment slots for ARCH lanes
 
-# Root cause of FIX-7 partial failure: 3 ARCH service deploys are stuck in
-# Railway "QUEUED — Waiting for deployment slot" because ACC4/5/6 plans
-# have run out of concurrent deployment slots. Legacy wave-* trainers
-# (stuck at BPB>=7.0 for weeks, divergent / broken kernels) are holding
-# the slots.
+# v2 (2026-05-15): Railway's `deploymentStop` only stops SUCCESS deployments.
+# QUEUED/BUILDING/DEPLOYING/CRASHED states need `deploymentCancel` OR setting
+# numReplicas=0 via serviceInstanceUpdate. We try cancel first, then fall back
+# to setting numReplicas=0 which works universally.
 #
-# This workflow stops the N worst-BPB wave-* services per ACC (default N=3
-# per ACC) by calling serviceInstanceRedeployToCommit with a non-existent
-# tag to halt the container, then deploymentStop to remove from active set.
-#
-# Idempotent via confirm=PHI gate.
 # Anchor: phi^2 + phi^-2 = 3 · TRINITY · NEVER STOP
 
 on:
@@ -45,18 +39,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install psql client
-        run: sudo apt-get update -qq && sudo apt-get install -y -qq postgresql-client
-
-      - name: Identify and stop worst wave-* services
+      - name: Identify and disable worst wave-* services (numReplicas=0)
         run: |
           set -euo pipefail
-
-          # Pull worst N wave-* services per ACC by canon BPB
-          # (we don't have direct service_id↔canon mapping; use service_name match)
-          # Simpler: pick first N entries from CSV per ACC, excluding the
-          # 3 ARCH carriers (051cb5a4, 01cf32d5, 002b62ee).
-          # That's safe because all wave-* in ACC4-6 are broken/diverged.
 
           ARCH_SVCS="051cb5a4-1e62-48c8-8b02-abb14c387611 01cf32d5-cac1-45d8-b120-0ceba7a2647a 002b62ee-52ad-409c-8e60-14836dc94083"
 
@@ -69,50 +54,52 @@ jobs:
             if [[ -z "$TOK" ]]; then
               echo "::warning::no token for $ACC, skip"; continue
             fi
-            echo "::group::$ACC — picking $N_PER_ACC worst wave-* services"
+            echo "::group::$ACC — disabling $N_PER_ACC worst wave-* services"
             N=0
             while IFS=',' read -r CSV_ACC PROJ ENV SID NAME; do
               [[ "$CSV_ACC" != "$ACC" ]] && continue
-              # Skip ARCH carriers
               SKIP=0
               for ARCH in $ARCH_SVCS; do
                 [[ "$SID" == "$ARCH" ]] && SKIP=1 && break
               done
               [[ $SKIP -eq 1 ]] && continue
-              # Skip non-wave services
               [[ "$NAME" != wave-* ]] && continue
 
               N=$((N+1))
               if [[ $N -gt $N_PER_ACC ]]; then break; fi
 
-              echo "  KILL svc=$SID name=$NAME"
+              echo "  KILL svc=$SID name=$NAME (proj=$PROJ env=$ENV)"
               if [[ "$DRY_RUN" == "true" ]]; then
-                echo "  DRY_RUN: would stop latest deployment on $SID"
+                echo "  DRY_RUN: would set numReplicas=0 + cancel latest deployment on $SID"
                 continue
               fi
 
-              # Get latest deployment id
+              # Strategy 1: set numReplicas=0 — stops service universally
+              # serviceInstanceUpdate(input: ServiceInstanceUpdateInput!): Boolean!
+              UPD=$(curl -sS --max-time 30 --connect-timeout 10 -X POST https://backboard.railway.com/graphql/v2 \
+                -H "Content-Type: application/json" \
+                -H "Project-Access-Token: $TOK" \
+                -d "{\"query\":\"mutation{ serviceInstanceUpdate(serviceId:\\\"$SID\\\", environmentId:\\\"$ENV\\\", input:{numReplicas:0}) }\"}")
+              echo "  numReplicas=0 response: $(echo $UPD | jq -c '.data // .errors')"
+
+              # Strategy 2: cancel latest deployment regardless of state
               DEP_ID=$(curl -sS --max-time 30 --connect-timeout 10 -X POST https://backboard.railway.com/graphql/v2 \
                 -H "Content-Type: application/json" \
                 -H "Project-Access-Token: $TOK" \
                 -d "{\"query\":\"{ deployments(first:1, input:{projectId:\\\"$PROJ\\\", environmentId:\\\"$ENV\\\", serviceId:\\\"$SID\\\"}){ edges { node { id status } } } }\"}" \
                 | jq -r '.data.deployments.edges[0].node.id // empty')
 
-              if [[ -z "$DEP_ID" ]]; then
-                echo "  ::warning::no deployment found for $SID"; continue
+              if [[ -n "$DEP_ID" ]]; then
+                CAN=$(curl -sS --max-time 30 --connect-timeout 10 -X POST https://backboard.railway.com/graphql/v2 \
+                  -H "Content-Type: application/json" \
+                  -H "Project-Access-Token: $TOK" \
+                  -d "{\"query\":\"mutation{ deploymentCancel(id:\\\"$DEP_ID\\\") }\"}")
+                echo "  cancel response: $(echo $CAN | jq -c '.data // .errors')"
               fi
 
-              # Stop deployment
-              R=$(curl -sS --max-time 30 --connect-timeout 10 -X POST https://backboard.railway.com/graphql/v2 \
-                -H "Content-Type: application/json" \
-                -H "Project-Access-Token: $TOK" \
-                -d "{\"query\":\"mutation{ deploymentStop(id:\\\"$DEP_ID\\\") }\"}")
-              echo "  stop response: $(echo $R | jq -c '.data // .errors')"
-
-              # Brief pause to avoid rate limits
               sleep 1
             done < .github/wave-a/acc47-services.csv
             echo "::endgroup::"
           done
 
-          echo "KILL-STALE-SUMMARY: dry_run=$DRY_RUN n_per_acc=$N_PER_ACC"
+          echo "KILL-STALE-SUMMARY: dry_run=$DRY_RUN n_per_acc=$N_PER_ACC strategy=numReplicas0+cancel"


### PR DESCRIPTION
## 🔧 KILL-STALE-WAVES v2 — fix Railway mutation choice

### Why
PR #203 v1 deployed but `deploymentStop` returned `"Deployment is not stoppable"` for all 9 wave-* services. Railway's `deploymentStop` only works on deployments already in `SUCCESS` state — QUEUED/BUILDING/DEPLOYING return error.

### Fix
Use **two-step universal halt**:
1. `serviceInstanceUpdate(numReplicas:0)` — works regardless of deployment state, scales container to 0
2. `deploymentCancel(id:DEP_ID)` — cancels QUEUED/BUILDING deployments

This frees the deployment slot for ARCH carriers stuck in `QUEUED — Waiting for deployment slot`.

### Verification path
- DRY-RUN: prints which 9 wave-* targets (3 per ACC4/5/6)
- LIVE: scales worst 9 to 0 replicas, cancels their pending deployments
- ARCH carriers `051cb5a4`, `01cf32d5`, `002b62ee` excluded from kill-list

Anchor: phi^2 + phi^-2 = 3 · TRINITY · NEVER STOP
