### PR TITLE
fix(gardener-brain): STAGE-2f BRAIN revive dispatch was silently failing (PASS-24)

### DIFF
--- a/.github/workflows/gardener-loop.yml
+++ b/.github/workflows/gardener-loop.yml
@@ -10,6 +10,7 @@ on:
 permissions:
   contents: write     # для auto-commit улучшений
   issues: write
+  actions: write      # v3.0.1 (PASS-24): STAGE-2f BRAIN revive dispatches sibling workflows
 jobs:
   hunt:
     runs-on: ubuntu-24.04
@@ -505,9 +506,20 @@ jobs:
             fi
             echo "  🚑 REVIVE $LANE → $WF"
             # Most revive workflows take confirm=PHI input. Try with confirm first, fall back to no-input.
-            gh workflow run "$WF" --repo gHashTag/trios-railway -f confirm=PHI 2>/dev/null \
-              || gh workflow run "$WF" --repo gHashTag/trios-railway 2>/dev/null \
-              && DISPATCHED=$((DISPATCHED+1))
+            # v3.0.1 (2026-05-15 PASS-24 PATCH): drop 2>/dev/null (was hiding gh errors), fix
+            # ||/&& precedence bug that left DISPATCHED=0 even when dispatch succeeded.
+            DISPATCH_OK=0
+            if gh workflow run "$WF" --repo gHashTag/trios-railway -f confirm=PHI; then
+              DISPATCH_OK=1
+            elif gh workflow run "$WF" --repo gHashTag/trios-railway; then
+              DISPATCH_OK=1
+            fi
+            if [ "$DISPATCH_OK" = "1" ]; then
+              DISPATCHED=$((DISPATCHED+1))
+              echo "    ✅ dispatched"
+            else
+              echo "    ❌ dispatch FAILED for $LANE → $WF (see gh output above)"
+            fi
           done
           echo "brain_revived=$DISPATCHED"       >> "$GITHUB_OUTPUT"
           echo "brain_skipped_idemp=$SKIPPED_IDEMP" >> "$GITHUB_OUTPUT"
@@ -697,7 +709,7 @@ jobs:
               'woken', ${{ steps.stall.outputs.woken || 0 }},
               'ssot_missing', ${{ steps.ssot_prop.outputs.ssot_missing || 0 }},
               'ssot_propagated', ${{ steps.ssot_prop.outputs.ssot_propagated || 0 }},
-              'mode', '$MODE', 'version', 'v3.0-trinity-brain',
+              'mode', '$MODE', 'version', 'v3.0.1-trinity-brain-dispatch-fix',
               'brain_util_pct', ${{ steps.brain.outputs.utilization_pct || 0 }},
               'brain_verdict', '${{ steps.brain.outputs.verdict || 'UNKNOWN' }}',
               'brain_stalled', '${{ steps.brain.outputs.lanes_stalled || '' }}',


### PR DESCRIPTION
## TL;DR

PR #204 transplanted the BRAIN, but STAGE-2f never actually fired any `gh workflow run`. R5-verified against run [25933024959](https://github.com/gHashTag/trios-railway/actions/runs/25933024959):

```
🚑 REVIVE ARCH → mass-deploy-arch.yml
🚑 REVIVE CHAMPION → redeploy-single.yml
🚑 REVIVE EXPEDITION → redeploy-single.yml
🧠 BRAIN revive: dispatched=0 skipped_idempotency=0   ← LIES
```

Cross-check: `mass-deploy-arch.yml` last run **14:03Z** (4 hours before STAGE-2f fired at 18:21Z). `redeploy-single.yml` last run **14:37Z**. No new runs. Dispatch failed silently.

## Root cause (two bugs)

**Bug 1 — shell precedence.** Original:
```bash
gh A 2>/dev/null || gh B 2>/dev/null && DISPATCHED=$((DISPATCHED+1))
```
Bash parses as `A || (B && C)`. When A succeeds → short-circuits → counter never increments. So even if the dispatch worked, the counter said 0 — observed exactly that.

**Bug 2 — silenced errors.** `2>/dev/null` hid the actual gh CLI error. Most likely:
```
HTTP 403: Resource not accessible by integration
```
because the workflow didn't have `actions: write` permission and `GITHUB_TOKEN` was scoped read-only for actions.

## Fix

1. Replace `A || B && C` with explicit `if A; then OK=1; elif B; then OK=1; fi` + separate counter bump.
2. Remove `2>/dev/null` so gh errors surface in logs.
3. Add `actions: write` to job permissions (defensive — matches the real intent of STAGE-2f / STAGE-3b).
4. Bump version stamp `v3.0 → v3.0.1`.

## Verification plan

Next gardener tick (one of :07 / :22 / :37 / :52 UTC) should show:

```
🚑 REVIVE ARCH → mass-deploy-arch.yml
    ✅ dispatched
🚑 REVIVE CHAMPION → redeploy-single.yml
    ✅ dispatched
🚑 REVIVE EXPEDITION → redeploy-single.yml
    ✅ dispatched
🧠 BRAIN revive: dispatched=3 skipped_idempotency=0
```

AND new runs visible under `mass-deploy-arch.yml/runs` + `redeploy-single.yml/runs` with `created_at` matching the gardener tick.

---

$\varphi^2 + \varphi^{-2} = 3$ · TRINITY · GARDENER-BRAIN · DEFENSE 2026-06-15