### PR TITLE
🔧 fix(mass-revive): ARCH carriers first + 60min timeout

### DIFF
--- a/.github/workflows/mass-revive-strategy.yml
+++ b/.github/workflows/mass-revive-strategy.yml
@@ -33,7 +33,7 @@ jobs:
   mass-revive:
     if: ${{ inputs.confirm == 'PHI' }}
     runs-on: ubuntu-24.04
-    timeout-minutes: 15
+    timeout-minutes: 60
     env:
       T1: ${{ secrets.RAILWAY_TOKEN_ACC1 }}
       T2: ${{ secrets.RAILWAY_TOKEN_ACC2 }}
@@ -60,7 +60,7 @@ jobs:
                    trainer_bin, w_jepa, w_nca
             FROM ssot.scarab_strategy
             WHERE status = 'active'
-            ORDER BY account, service_id
+            ORDER BY CASE WHEN service_id IN ('051cb5a4-1e62-48c8-8b02-abb14c387611','01cf32d5-cac1-45d8-b120-0ceba7a2647a','002b62ee-52ad-409c-8e60-14836dc94083') THEN 0 ELSE 1 END, account, service_id
           " > strategy.txt
           echo "Strategy rows ($(wc -l < strategy.txt)):"
           cat strategy.txt


### PR DESCRIPTION
Previous mass-revive run (#25935627840) hit 15min timeout-minutes cap after 13/15 STRATEGY services; never reached the 3 ARCH carriers (051cb5a4 / 01cf32d5 / 002b62ee).

Fix: SQL ORDER BY now puts ARCH UUIDs first (priority 0), STRATEGY alphabetically after. timeout-minutes 15→60.

Anchor: phi^2 + phi^-2 = 3