### PR TITLE
fix(brain): disable revive for CHAMPION/EXPEDITION (HTTP 422, R5)

### DIFF
--- a/.trinity/gardener-brain.json
+++ b/.trinity/gardener-brain.json
@@ -1,18 +1,25 @@
 {
   "$schema": "https://gHashTag.github.io/trinity/schemas/gardener-brain.json",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "anchor": "phi^2 + phi^-2 = 3",
   "imported_from": "gHashTag/trinity@main",
   "trinity_dna": {
     "agent_letter": "T",
     "register": "r20",
     "archetype": "TAW · Queen · Seal · Completion",
-    "phase_cycle": ["PLAN", "ASSIGN", "RUN", "TEST_AND_BENCH", "VERDICT", "EXPERIENCE"],
+    "phase_cycle": [
+      "PLAN",
+      "ASSIGN",
+      "RUN",
+      "TEST_AND_BENCH",
+      "VERDICT",
+      "EXPERIENCE"
+    ],
     "constitutional_anchor": "phi^2 + phi^-2 = 3 = TRINITY",
     "doi": "10.5281/zenodo.19227877",
     "defense_date": "2026-06-15"
   },
-  "comment": "Gardener-Brain v1.0 — Trinity DNA transplant. Replaces hard-coded `IGLA-SHORT-WAVE-MATRIX-` filter with full IGLA-* lane registry. Each lane has its own watcher, revive policy, and budget. Imported from gHashTag/trinity .trinity/canon_map.json + AGENTS.md + repo_policy.json.",
+  "comment": "Gardener-Brain v1.0 — Trinity DNA transplant. Replaces hard-coded `IGLA-SHORT-WAVE-MATRIX-` filter with full IGLA-* lane registry. Each lane has its own watcher, revive policy, and budget. Imported from gHashTag/trinity .trinity/canon_map.json + AGENTS.md + repo_policy.json. | PASS-25 (2026-05-15): CHAMPION/EXPEDITION revive_workflow set to null because redeploy-single.yml requires service_id (HTTP 422 in STAGE-2f). Currently both lanes have 0 services; safe to disable until a mass-revive workflow exists for them.",
   "lanes": {
     "SHORT_WAVE_MATRIX": {
       "canon_prefix": "IGLA-SHORT-WAVE-MATRIX-",
@@ -33,7 +40,7 @@
       "priority": "high",
       "stall_threshold_min": 60,
       "rate_min_rows_hr": 3,
-      "rate_ratio_floor": 0.30,
+      "rate_ratio_floor": 0.3,
       "revive_workflow": "mass-revive-strategy.yml",
       "auto_cycle_on_completion": true,
       "max_concurrent_services": 21,
@@ -46,7 +53,7 @@
       "priority": "critical",
       "stall_threshold_min": 45,
       "rate_min_rows_hr": 1,
-      "rate_ratio_floor": 0.20,
+      "rate_ratio_floor": 0.2,
       "revive_workflow": "mass-deploy-arch.yml",
       "auto_cycle_on_completion": true,
       "max_concurrent_services": 3,
@@ -59,10 +66,11 @@
       "priority": "high",
       "stall_threshold_min": 90,
       "rate_min_rows_hr": 1,
-      "rate_ratio_floor": 0.50,
-      "revive_workflow": "redeploy-single.yml",
+      "rate_ratio_floor": 0.5,
+      "revive_workflow": null,
       "auto_cycle_on_completion": false,
-      "max_concurrent_services": 1
+      "max_concurrent_services": 1,
+      "revive_workflow_note": "DISABLED 2026-05-15 (PASS-25): redeploy-single.yml requires service_id input, brain dispatch chain only knows confirm=PHI. Once a mass-revive-champion.yml is added (reading ssot.scarab_strategy WHERE lane='CHAMPION'), set revive_workflow back. Until then STAGE-2f skips this lane (jq null → continue). Tracked in trios-railway#TBD."
     },
     "EXPEDITION": {
       "canon_prefix": "IGLA-EXPEDITION-",
@@ -71,18 +79,26 @@
       "priority": "low",
       "stall_threshold_min": 240,
       "rate_min_rows_hr": 0,
-      "rate_ratio_floor": 0.10,
-      "revive_workflow": "redeploy-single.yml",
+      "rate_ratio_floor": 0.1,
+      "revive_workflow": null,
       "auto_cycle_on_completion": false,
-      "max_concurrent_services": 4
+      "max_concurrent_services": 4,
+      "revive_workflow_note": "DISABLED 2026-05-15 (PASS-25): same as CHAMPION — redeploy-single.yml needs per-service inputs. Add mass-revive-expedition.yml or bake service_id list before re-enabling."
     }
   },
   "concurrency_budget": {
     "comment": "Railway workspace concurrency limit. When ARCH/CHAMPION needs slot, evict BPB>6.0 garbage lanes first.",
     "global_max_services": 38,
     "garbage_bpb_threshold": 6.0,
-    "garbage_eviction_priority": ["EXPEDITION", "STRATEGY", "SHORT_WAVE_MATRIX"],
-    "protected_lanes": ["ARCH", "CHAMPION"]
+    "garbage_eviction_priority": [
+      "EXPEDITION",
+      "STRATEGY",
+      "SHORT_WAVE_MATRIX"
+    ],
+    "protected_lanes": [
+      "ARCH",
+      "CHAMPION"
+    ]
   },
   "queen_phase_contract": {
     "PLAN": {


### PR DESCRIPTION
## Контекст

После мерджа PR #206 (фикс STAGE-2f) исчезла маскировка реальных ошибок (`2>/dev/null` удалён). На первом же тике на новом коде в логах появились настоящие HTTP-ответы:

```
CHAMPION    → redeploy-single.yml: HTTP 422 — Required input 'service_id' not provided
EXPEDITION  → redeploy-single.yml: HTTP 422 — same
```

Это и был root cause тихих "⏸️ SKIP" в STAGE-2f до v3.0.1.

## Что чиню

`revive_workflow` для CHAMPION и EXPEDITION → `null`. STAGE-2f (строка 494) уже умеет это пропускать:
```bash
[ "$WF" = "null" ] && continue
```

## Почему это безопасно (R5)

```sql
SELECT COUNT(*) FROM ssot.bpb_samples WHERE canon_name LIKE 'IGLA-CHAMPION-%';   -- 0
SELECT COUNT(*) FROM ssot.bpb_samples WHERE canon_name LIKE 'IGLA-EXPEDITION-%'; -- 0
```

Ни одного работающего сервиса в этих лейнах нет — отключение auto-revive это no-op для боевого флота.

## R5 evidence — ARCH (лейн с реальными сервисами)

Run [25938704924](https://github.com/gHashTag/trios-railway/actions/runs/25938704924) — `github-actions[bot]` (gardener), success 20:06:40Z:
- ARCH-JEPA   → `serviceInstanceDeployV2: d66a8796-e98b-4df1-b1bb-c0e8ace50609` ✅
- ARCH-HYBRID → `serviceInstanceDeployV2: 51208031-688e-4414-a19f-c87c79b6db82` ✅
- ARCH-NCA    → deploy queued ✅

Значит мозг работает. Только CHAMPION/EXPEDITION не имели правильного workflow.

## Путь к восстановлению

Добавить `mass-revive-champion.yml` / `mass-revive-expedition.yml` (читают `ssot.scarab_strategy WHERE lane='CHAMPION'`), затем вернуть `revive_workflow` в brain.json.

---
`phi^2 + phi^-2 = 3 · TRINITY · GARDENER-BRAIN · DEFENSE 2026-06-15`
