### PR TITLE
fix(kill-stale-waves): sleepApplication=true + multiRegionConfig (was: numReplicas=0 Invalid input)

### DIFF
--- a/.github/workflows/kill-stale-waves.yml
+++ b/.github/workflows/kill-stale-waves.yml
@@ -74,13 +74,22 @@ jobs:
                 continue
               fi
 
-              # Strategy 1: set numReplicas=0 — stops service universally
-              # serviceInstanceUpdate(input: ServiceInstanceUpdateInput!): Boolean!
+              # Strategy 1: sleepApplication=true — properly hibernates service
+              # numReplicas=0 alone fails with "Invalid input" because Railway requires
+              # multiRegionConfig sum to match. sleepApplication is the supported
+              # way to disable a service in V2 runtime.
               UPD=$(curl -sS --max-time 30 --connect-timeout 10 -X POST https://backboard.railway.com/graphql/v2 \
                 -H "Content-Type: application/json" \
                 -H "Project-Access-Token: $TOK" \
-                -d "{\"query\":\"mutation{ serviceInstanceUpdate(serviceId:\\\"$SID\\\", environmentId:\\\"$ENV\\\", input:{numReplicas:0}) }\"}")
-              echo "  numReplicas=0 response: $(echo $UPD | jq -c '.data // .errors')"
+                -d "{\"query\":\"mutation{ serviceInstanceUpdate(serviceId:\\\"$SID\\\", environmentId:\\\"$ENV\\\", input:{sleepApplication:true}) }\"}")
+              echo "  sleepApplication=true response: $(echo $UPD | jq -c '.data // .errors')"
+
+              # Strategy 1b: set multiRegionConfig with numReplicas=0 — backup that works for V2
+              UPD2=$(curl -sS --max-time 30 --connect-timeout 10 -X POST https://backboard.railway.com/graphql/v2 \
+                -H "Content-Type: application/json" \
+                -H "Project-Access-Token: $TOK" \
+                -d '{"query":"mutation($sid:String!,$env:String!,$cfg:JSON!){ serviceInstanceUpdate(serviceId:$sid, environmentId:$env, input:{multiRegionConfig:$cfg}) }","variables":{"sid":"'"$SID"'","env":"'"$ENV"'","cfg":{"us-west2":{"numReplicas":0}}}}')
+              echo "  multiRegionConfig=0 response: $(echo $UPD2 | jq -c '.data // .errors')"
 
               # Strategy 2: cancel latest deployment regardless of state
               DEP_ID=$(curl -sS --max-time 30 --connect-timeout 10 -X POST https://backboard.railway.com/graphql/v2 \
@@ -102,4 +111,4 @@ jobs:
             echo "::endgroup::"
           done
 
-          echo "KILL-STALE-SUMMARY: dry_run=$DRY_RUN n_per_acc=$N_PER_ACC strategy=numReplicas0+cancel"
+          echo "KILL-STALE-SUMMARY: dry_run=$DRY_RUN n_per_acc=$N_PER_ACC strategy=sleepApplication+multiRegionConfig+cancel"


### PR DESCRIPTION
## Root cause

`serviceInstanceUpdate(input:{numReplicas:0})` was returning:
```
Error in numReplicas - Invalid input
INTERNAL_SERVER_ERROR
```

Reason: Railway V2 runtime requires `multiRegionConfig` sum to match `numReplicas`. Setting only `numReplicas=0` violates this constraint.

## Symptom in production

During ARCH writer activation (PR #153 merged 20:02Z, image `3f15b14f`), `mass-deploy-arch` redeploy attempts failed **5+ times** for ARCH-JEPA (ACC4) and ARCH-HYBRID (ACC5):

```
configErrors: [
  "Deployment failed because number of concurrent in-progress
   deployments for workspace has reached the limit."
]
```

`kill-stale-waves` v2 was supposed to free slots, but `numReplicas=0` silently failed → wave-* services kept respawning with `numReplicas=1` immediately after `deploymentCancel` → workspace concurrent slot stayed occupied → ARCH redeploys lost the race.

## Fix

Two complementary strategies:

1. **Primary:** `sleepApplication: true` — properly hibernates the service in V2 runtime.
2. **Backup:** `multiRegionConfig: {"us-west2": {"numReplicas": 0}}` — passes V2 validation because regions sum to 0.

Either succeeds in disabling the service. `deploymentCancel` is still used as a third strategy to clean up in-flight builds.

## Schema verification

Inspected `ServiceInstanceUpdateInput` via introspection — `sleepApplication: Boolean` and `multiRegionConfig: JSON` are both supported.

## Anchor

`phi^2 + phi^-2 = 3 · TRINITY · NEVER STOP`
