### PR TITLE
L-SS7: deprecate mass-deploy-arch + mass-revive-strategy

### DIFF
--- a/.github/workflows/mass-deploy-arch.yml
+++ b/.github/workflows/mass-deploy-arch.yml
@@ -1,4 +1,10 @@
-name: MASS-DEPLOY-ARCH — deploy JEPA-T + NCA + HYBRID on ACC4-6
+name: "[DEPRECATED L-SS7] MASS-DEPLOY-ARCH — replaced by Sovereign Scarab v4 pull-loop"
+
+# DEPRECATED 2026-05-16 by L-SS7 (gHashTag/trios#940).
+# Replaced by ssot.scarab_strategy + Queen-Hive MCP writer.
+# NO Railway API, NO variableUpsert. See ADR-0042-pull-loop.
+#
+# Original purpose:
 
 # FIX-7: read 3 ARCH-lanes (arch-jepa-1, arch-hybrid-1, arch-nca-1) from
 # ssot.scarab_strategy and deploy each to a real Railway service on ACC4-6.
@@ -30,8 +36,22 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  deprecated:
+    name: "DEPRECATED — use Queen-Hive MCP (L-SS3)"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Block run
+        run: |
+          echo "::error::This workflow is DEPRECATED by L-SS7 (gHashTag/trios#940)."
+          echo "::error::Sovereign Scarab v4 pull-loop replaces push-based deploys."
+          echo "::error::Use Queen-Hive MCP writer (crates/queen-hive-mcp) or call"
+          echo "::error::ssot.spawn_scarab / ssot.bump_strategy_v2 directly."
+          echo "::error::No Railway API. No variableUpsert. See ADR-0042-pull-loop."
+          exit 1
+
   deploy:
-    name: variableUpsert + serviceInstanceDeployV2 (3 ARCH services)
+    name: "[disabled] variableUpsert + serviceInstanceDeployV2 (3 ARCH services)"
+    if: false  # L-SS7: never runs — kept for git history only
     runs-on: ubuntu-24.04
     timeout-minutes: 12
 

--- a/.github/workflows/mass-revive-strategy.yml
+++ b/.github/workflows/mass-revive-strategy.yml
@@ -1,4 +1,8 @@
-name: MASS-REVIVE-STRATEGY — apply ssot.scarab_strategy → variableUpsert + redeploy
+name: "[DEPRECATED L-SS7] MASS-REVIVE-STRATEGY — replaced by Sovereign Scarab v4 pull-loop"
+
+# DEPRECATED 2026-05-16 by L-SS7 (gHashTag/trios#940).
+# Sovereign Scarab v4 reads ssot.scarab_strategy itself — push-revive no
+# longer needed. Use Queen-Hive MCP (crates/queen-hive-mcp) for control.
 
 # AUTONOMOUS REVIVAL of the 18 strategy rows held by the queen-hive scheduler.
 # `ssot.scarab_strategy` lists (service_id, account, format, optimizer, hidden,
@@ -30,8 +34,19 @@ on:
         default: "false"
 
 jobs:
+  deprecated:
+    name: "DEPRECATED — use Queen-Hive MCP (L-SS3)"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Block run
+        run: |
+          echo "::error::This workflow is DEPRECATED by L-SS7 (gHashTag/trios#940)."
+          echo "::error::Scarab v4 pulls ssot.scarab_strategy by itself; no revive needed."
+          echo "::error::Use Queen-Hive MCP writer or call ssot.bump_strategy_v2 directly."
+          exit 1
+
   mass-revive:
-    if: ${{ inputs.confirm == 'PHI' }}
+    if: false  # L-SS7: never runs — kept for git history only
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     env:


### PR DESCRIPTION
Closes trios-trainer-igla#158 · Epic gHashTag/trios#940

Sovereign Scarab v4 (ADR-0042) делает push-revive ненужным — scarab'ы сами читают `ssot.scarab_strategy` и graceful-restart-ятся при изменении fingerprint.

## Что
- Оба workflow получают первый job `deprecated` который сразу падает с `::error::` сообщением и инструкцией куда идти
- Старый job помечен `if: false` (история сохраняется в git, но не запускается)
- Title теперь `[DEPRECATED L-SS7] ...`

## Acceptance — G-SS-12
- [x] Файлы помечены deprecated
- [ ] После мерджа L-SS3 (Queen-Hive MCP): `rg -n 'variableUpsert|RAILWAY_API_TOKEN' .` пусто в новых ветках

Anchor: φ² + φ⁻² = 3