### PR TITLE
L-SS5: heartbeat-TTL janitor function (closes #89)

### DIFF
--- a/migrations/0013_heartbeat_janitor.sql
+++ b/migrations/0013_heartbeat_janitor.sql
@@ -1,0 +1,151 @@
+-- 0013_heartbeat_janitor.sql
+-- L-SS5 (gHashTag/trios-railway#212) — Sovereign Scarab v4 heartbeat-TTL janitor.
+-- Closes gHashTag/trios-trainer-igla#89. Epic: gHashTag/trios#940.
+--
+-- Adds:
+--   1. ssot.janitor_release_stale()  — advisory-lock-guarded cleanup function
+--   2. ssot.janitor_status           — observability view: lock holder + hourly stats
+--
+-- Advisory-lock contract (G-SS-10):
+--   Lock key = 0xDEAD_BEEF = 3735928559
+--   Only one Postgres session may run the janitor at a time.
+--   pg_try_advisory_lock() is used (non-blocking); if another session already
+--   holds the lock this invocation is a no-op and returns 0.
+--   Lock is released explicitly via pg_advisory_unlock() in the EXCEPTION block
+--   and in the normal path, so the session-level lock is never leaked.
+--
+-- Anchor: phi^2 + phi^-2 = 3 · DEFENSE 2026-06-15
+
+BEGIN;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 1. janitor_release_stale()
+-- ─────────────────────────────────────────────────────────────────────────────
+
+CREATE OR REPLACE FUNCTION ssot.janitor_release_stale()
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+    _lock_key  bigint  := x'DEADBEEF'::bigint;  -- 3735928559
+    _got_lock  boolean;
+    _released  integer := 0;
+BEGIN
+    -- Try to acquire session-level advisory lock (non-blocking).
+    -- Contract G-SS-10: only one janitor runs at a time across the fleet.
+    _got_lock := pg_try_advisory_lock(_lock_key);
+
+    IF NOT _got_lock THEN
+        RAISE NOTICE 'janitor_release_stale: advisory lock 0xDEADBEEF already held by another session — skipping';
+        RETURN 0;
+    END IF;
+
+    BEGIN
+        -- Release scarabs that have been dead (no heartbeat) for > 600 seconds.
+        -- ssot.scarab_dead is the canonical source-of-truth view (L-SS4, #211).
+        UPDATE ssot.scarab_strategy
+        SET    status = 'released'
+        WHERE  canon_name IN (
+            SELECT canon_name
+            FROM   ssot.scarab_dead
+            WHERE  age_seconds > 600
+        );
+
+        GET DIAGNOSTICS _released = ROW_COUNT;
+
+        RAISE NOTICE 'janitor_release_stale: released % stale scarab(s)', _released;
+
+        -- Release advisory lock — normal path.
+        PERFORM pg_advisory_unlock(_lock_key);
+
+    EXCEPTION WHEN OTHERS THEN
+        -- Always release the lock even on error to avoid session-level leak.
+        PERFORM pg_advisory_unlock(_lock_key);
+        RAISE;
+    END;
+
+    RETURN _released;
+END;
+$$;
+
+COMMENT ON FUNCTION ssot.janitor_release_stale() IS
+'L-SS5 (#212, closes gHashTag/trios-trainer-igla#89, epic gHashTag/trios#940): '
+'Heartbeat-TTL janitor. Uses advisory lock 0xDEADBEEF (3735928559) per G-SS-10 contract '
+'to ensure at-most-one execution across the fleet. '
+'Releases scarabs whose last heartbeat is older than 600 seconds. '
+'Returns the count of rows transitioned to status=''released''. '
+'Non-blocking: returns 0 immediately if lock is already held.';
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 2. janitor_status view
+-- ─────────────────────────────────────────────────────────────────────────────
+
+CREATE OR REPLACE VIEW ssot.janitor_status AS
+SELECT
+    -- Current advisory-lock holder (NULL when lock is free)
+    lock_info.pid                                           AS lock_holder_pid,
+    lock_info.usename                                       AS lock_holder_user,
+    lock_info.application_name                             AS lock_holder_app,
+    lock_info.state                                        AS lock_holder_state,
+    lock_info.query_start                                  AS lock_holder_query_start,
+
+    -- How many scarabs were released by the janitor in the last hour
+    -- We detect this via status='released' AND updated_at within the last hour.
+    -- (updated_at is set by a trigger or explicit SET; relies on ssot.scarab_strategy.updated_at
+    --  being maintained — same assumption as the rest of the SSOT layer.)
+    COALESCE(hourly.released_count, 0)                     AS released_last_hour,
+
+    -- Current dead-but-not-yet-released count (candidates for next run)
+    COALESCE(pending.pending_count, 0)                     AS pending_release_count,
+
+    now()                                                  AS observed_at
+
+FROM
+    -- Lock holder sub-query: join pg_locks → pg_stat_activity
+    (
+        SELECT
+            a.pid,
+            a.usename,
+            a.application_name,
+            a.state,
+            a.query_start
+        FROM pg_locks l
+        JOIN pg_stat_activity a ON a.pid = l.pid
+        WHERE l.locktype    = 'advisory'
+          AND l.classid     = (x'DEADBEEF'::bigint >> 32)::int   -- high 32 bits
+          AND l.objid       = (x'DEADBEEF'::bigint & x'FFFFFFFF'::bigint)::int  -- low 32 bits
+          AND l.granted     = true
+        LIMIT 1
+    ) lock_info
+
+    CROSS JOIN LATERAL (
+        SELECT COUNT(*) AS released_count
+        FROM ssot.scarab_strategy
+        WHERE status     = 'released'
+          AND updated_at >= now() - INTERVAL '1 hour'
+    ) hourly
+
+    CROSS JOIN LATERAL (
+        SELECT COUNT(*) AS pending_count
+        FROM ssot.scarab_dead
+        WHERE age_seconds > 600
+    ) pending;
+
+COMMENT ON VIEW ssot.janitor_status IS
+'L-SS5 (#212): Observability view for the heartbeat-TTL janitor. '
+'Shows: current advisory-lock holder (pid/user/app), count of scarabs released in the last hour, '
+'and count of stale scarabs pending release on next janitor run.';
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Sanity check
+-- ─────────────────────────────────────────────────────────────────────────────
+DO $$
+DECLARE
+    _pending int;
+BEGIN
+    SELECT pending_release_count INTO _pending FROM ssot.janitor_status;
+    RAISE NOTICE 'janitor_status.pending_release_count immediately after migration: %', _pending;
+END $$;
+
+COMMIT;


### PR DESCRIPTION
## L-SS5 — Sovereign Scarab v4: Heartbeat-TTL Janitor

Closes gHashTag/trios-trainer-igla#89
Epic: gHashTag/trios#940
Ref: gHashTag/trios-railway#212

---

### Summary

This migration adds the Sovereign Scarab v4 janitor layer: a PL/pgSQL function that periodically releases scarabs whose heartbeat has gone silent, plus an observability view for fleet operators.

**Files changed:**
- `migrations/0013_heartbeat_janitor.sql` — function + view + sanity-check DO block

---

### 1. `ssot.janitor_release_stale()` — cleanup function

- Attempts to acquire advisory lock `0xDEADBEEF` (3735928559) using `pg_try_advisory_lock()` **(non-blocking)**.
- If the lock is already held by another session → returns `0` immediately (at-most-one execution across the fleet — **G-SS-10 advisory-lock contract**).
- Runs:
  
  (builds on L-SS4 `ssot.scarab_dead` view, migration 0012)
- Emits `RAISE NOTICE` with the count of released rows.
- Releases the advisory lock in both the normal path and the `EXCEPTION` handler — **no session-level lock leak possible**.
- Returns `INT` count of transitioned rows.
- `SECURITY DEFINER`; `COMMENT ON FUNCTION` references issue #212, closes #89, epic #940.

### 2. `ssot.janitor_status` — observability view

| Column | Description |
|---|---|
| `lock_holder_pid` | PID of the session currently holding advisory lock 0xDEADBEEF (NULL = free) |
| `lock_holder_user` | DB user of the lock holder |
| `lock_holder_app` | `application_name` of the lock holder |
| `lock_holder_state` | Session state |
| `lock_holder_query_start` | When the lock-holding query started |
| `released_last_hour` | Scarabs with `status='released'` and `updated_at >= now()-1h` |
| `pending_release_count` | Scarabs in `ssot.scarab_dead` with `age_seconds > 600` (candidates for next run) |
| `observed_at` | Snapshot timestamp |

---

### G-SS-10 Acceptance Criteria

- [x] Advisory lock key `0xDEADBEEF` (3735928559) used exclusively for janitor mutual exclusion
- [x] Non-blocking acquisition via `pg_try_advisory_lock` (not `pg_advisory_lock`)
- [x] Lock released in both success and error paths (EXCEPTION block)
- [x] `RAISE NOTICE` reports released count for log observability
- [x] `SECURITY DEFINER` function with `COMMENT ON FUNCTION` referencing issue/epic
- [x] `ssot.janitor_status` exposes lock-holder pid for fleet operators
- [x] No DATABASE_URL required — migration is SQL-only, no side effects on apply

---

### Dependencies

| Migration | Purpose |
|---|---|
| `0012_scarab_dead_heartbeat.sql` | Provides `ssot.scarab_dead` view (L-SS4, #211) — required by this migration |

---

### Testing notes

- Run `SELECT ssot.janitor_release_stale();` — should return 0 if no scarabs are stale, or N if there are scarabs with `age_seconds > 600`.
- Run `SELECT * FROM ssot.janitor_status;` — `lock_holder_pid` will be NULL when no janitor is active; `pending_release_count` shows current backlog.
- Concurrent-safety test: hold advisory lock in one session (`SELECT pg_advisory_lock(3735928559)`), then call `janitor_release_stale()` in another — should return 0 immediately.

---

Anchor: phi^2 + phi^-2 = 3