### PR TITLE
refactor(tri-railway): narrow clippy debt for snapshot fleet

### DIFF
--- a/bin/tri-railway/src/main.rs
+++ b/bin/tri-railway/src/main.rs
@@ -45,6 +45,9 @@ struct Cli {
 }
 
 #[derive(Subcommand, Debug)]
+// rationale: clap subcommand enum — variants are short-lived stack values built
+// once at CLI parse time, so the size disparity flagged by large_enum_variant
+// does not justify Box-ing every variant.
 #[allow(clippy::large_enum_variant)]
 enum Cmd {
     /// Print the version and exit.
@@ -647,7 +650,78 @@ struct SnapshotDoc<'a> {
     totals: serde_json::Value,
 }
 
-#[allow(clippy::too_many_lines)]
+async fn snapshot_one_account(
+    spec: &str,
+    email_map: &std::collections::HashMap<String, String>,
+) -> Result<SnapshotAccount> {
+    let kv = parse_kv_list(spec);
+    let alias = kv.get("alias").cloned().unwrap_or_else(|| "?".to_string());
+    let label = kv.get("label").cloned().unwrap_or_else(|| "?".to_string());
+    let token_env = kv.get("token_env").cloned().unwrap_or_default();
+    let project_env = kv.get("project_env").cloned().unwrap_or_default();
+    let kind_env = kv.get("kind_env").cloned().unwrap_or_default();
+
+    let token = std::env::var(&token_env).ok();
+    let project = std::env::var(&project_env).ok();
+    let kind = if kind_env.is_empty() {
+        None
+    } else {
+        std::env::var(&kind_env).ok()
+    };
+
+    let (project_id, project_name, environments, services) = if let (Some(tok), Some(proj)) =
+        (token, project)
+    {
+        std::env::set_var("RAILWAY_TOKEN", &tok);
+        // rationale: per-account token kind override; default "project" matches
+        // Railway's Project-Access-Token header used by most project-scoped tokens.
+        let auth_val = kind.as_deref().unwrap_or("project");
+        std::env::set_var("RAILWAY_TOKEN_AUTH", auth_val);
+        let client = Client::from_env().map_err(|e| anyhow::anyhow!("from_env: {e}"))?;
+        let pid = ProjectId::from(proj);
+        match Q::project_view(&client, &pid).await {
+            Ok(pv) => {
+                let svcs = pv
+                    .services()
+                    .into_iter()
+                    .map(|s| {
+                        serde_json::json!({
+                            "id": s.id,
+                            "name": s.name,
+                            "createdAt": s.created_at,
+                        })
+                    })
+                    .collect::<Vec<_>>();
+                (Some(pv.id.clone()), Some(pv.name.clone()), Vec::new(), svcs)
+            }
+            Err(e) => {
+                tracing::warn!(alias = %alias, label = %label, error = %e, "skipping account");
+                (None, None, Vec::new(), Vec::new())
+            }
+        }
+    } else {
+        tracing::warn!(
+            alias = %alias,
+            label = %label,
+            "missing token_env or project_env in process env, recording empty"
+        );
+        (None, None, Vec::new(), Vec::new())
+    };
+
+    let count = services.len();
+    Ok(SnapshotAccount {
+        alias: alias.clone(),
+        project_label: label,
+        email: email_map.get(&alias).cloned(),
+        token_secret: token_env,
+        project_id,
+        project_name,
+        environments,
+        services,
+        service_count: count,
+    })
+}
+
 async fn run_snapshot_fleet(
     out: PathBuf,
     accounts: Vec<String>,
@@ -662,74 +736,10 @@ async fn run_snapshot_fleet(
     let mut total_services: usize = 0;
 
     for spec in &accounts {
-        let kv = parse_kv_list(spec);
-        let alias = kv.get("alias").cloned().unwrap_or_else(|| "?".to_string());
-        let label = kv.get("label").cloned().unwrap_or_else(|| "?".to_string());
-        let token_env = kv.get("token_env").cloned().unwrap_or_default();
-        let project_env = kv.get("project_env").cloned().unwrap_or_default();
-        let kind_env = kv.get("kind_env").cloned().unwrap_or_default();
-
-        let token = std::env::var(&token_env).ok();
-        let project = std::env::var(&project_env).ok();
-        let kind = if kind_env.is_empty() {
-            None
-        } else {
-            std::env::var(&kind_env).ok()
-        };
-
-        let (project_id, project_name, environments, services) = if let (Some(tok), Some(proj)) =
-            (token, project)
-        {
-            std::env::set_var("RAILWAY_TOKEN", &tok);
-            // Respect per-account token kind; default to "project" since most
-            // Railway tokens are project-scoped and use Project-Access-Token header.
-            let auth_val = kind.as_deref().unwrap_or("project");
-            std::env::set_var("RAILWAY_TOKEN_AUTH", auth_val);
-            let client = Client::from_env().map_err(|e| anyhow::anyhow!("from_env: {e}"))?;
-            let pid = ProjectId::from(proj);
-            match Q::project_view(&client, &pid).await {
-                Ok(pv) => {
-                    let svcs = pv
-                        .services()
-                        .into_iter()
-                        .map(|s| {
-                            serde_json::json!({
-                                "id": s.id,
-                                "name": s.name,
-                                "createdAt": s.created_at,
-                            })
-                        })
-                        .collect::<Vec<_>>();
-                    (Some(pv.id.clone()), Some(pv.name.clone()), Vec::new(), svcs)
-                }
-                Err(e) => {
-                    tracing::warn!(alias = %alias, label = %label, error = %e, "skipping account");
-                    (None, None, Vec::new(), Vec::new())
-                }
-            }
-        } else {
-            tracing::warn!(
-                alias = %alias,
-                label = %label,
-                "missing token_env or project_env in process env, recording empty"
-            );
-            (None, None, Vec::new(), Vec::new())
-        };
-
-        alias_set.insert(alias.clone());
-        let count = services.len();
-        total_services += count;
-        acc_out.push(SnapshotAccount {
-            alias: alias.clone(),
-            project_label: label,
-            email: email_map.get(&alias).cloned(),
-            token_secret: token_env,
-            project_id,
-            project_name,
-            environments,
-            services,
-            service_count: count,
-        });
+        let account = snapshot_one_account(spec, &email_map).await?;
+        alias_set.insert(account.alias.clone());
+        total_services += account.service_count;
+        acc_out.push(account);
     }
 
     let total_projects = acc_out.len();

--- a/bin/tri-railway/src/main.rs
+++ b/bin/tri-railway/src/main.rs
@@ -669,44 +669,43 @@ async fn snapshot_one_account(
         std::env::var(&kind_env).ok()
     };
 
-    let (project_id, project_name, environments, services) = if let (Some(tok), Some(proj)) =
-        (token, project)
-    {
-        std::env::set_var("RAILWAY_TOKEN", &tok);
-        // rationale: per-account token kind override; default "project" matches
-        // Railway's Project-Access-Token header used by most project-scoped tokens.
-        let auth_val = kind.as_deref().unwrap_or("project");
-        std::env::set_var("RAILWAY_TOKEN_AUTH", auth_val);
-        let client = Client::from_env().map_err(|e| anyhow::anyhow!("from_env: {e}"))?;
-        let pid = ProjectId::from(proj);
-        match Q::project_view(&client, &pid).await {
-            Ok(pv) => {
-                let svcs = pv
-                    .services()
-                    .into_iter()
-                    .map(|s| {
-                        serde_json::json!({
-                            "id": s.id,
-                            "name": s.name,
-                            "createdAt": s.created_at,
+    let (project_id, project_name, environments, services) =
+        if let (Some(tok), Some(proj)) = (token, project) {
+            std::env::set_var("RAILWAY_TOKEN", &tok);
+            // rationale: per-account token kind override; default "project" matches
+            // Railway's Project-Access-Token header used by most project-scoped tokens.
+            let auth_val = kind.as_deref().unwrap_or("project");
+            std::env::set_var("RAILWAY_TOKEN_AUTH", auth_val);
+            let client = Client::from_env().map_err(|e| anyhow::anyhow!("from_env: {e}"))?;
+            let pid = ProjectId::from(proj);
+            match Q::project_view(&client, &pid).await {
+                Ok(pv) => {
+                    let svcs = pv
+                        .services()
+                        .into_iter()
+                        .map(|s| {
+                            serde_json::json!({
+                                "id": s.id,
+                                "name": s.name,
+                                "createdAt": s.created_at,
+                            })
                         })
-                    })
-                    .collect::<Vec<_>>();
-                (Some(pv.id.clone()), Some(pv.name.clone()), Vec::new(), svcs)
+                        .collect::<Vec<_>>();
+                    (Some(pv.id.clone()), Some(pv.name.clone()), Vec::new(), svcs)
+                }
+                Err(e) => {
+                    tracing::warn!(alias = %alias, label = %label, error = %e, "skipping account");
+                    (None, None, Vec::new(), Vec::new())
+                }
             }
-            Err(e) => {
-                tracing::warn!(alias = %alias, label = %label, error = %e, "skipping account");
-                (None, None, Vec::new(), Vec::new())
-            }
-        }
-    } else {
-        tracing::warn!(
-            alias = %alias,
-            label = %label,
-            "missing token_env or project_env in process env, recording empty"
-        );
-        (None, None, Vec::new(), Vec::new())
-    };
+        } else {
+            tracing::warn!(
+                alias = %alias,
+                label = %label,
+                "missing token_env or project_env in process env, recording empty"
+            );
+            (None, None, Vec::new(), Vec::new())
+        };
 
     let count = services.len();
     Ok(SnapshotAccount {


### PR DESCRIPTION
## Summary
- audits the three clippy allow-list targets from #122 against the current tree
- removes the remaining live `#[allow(clippy::too_many_lines)]` by extracting `snapshot_one_account` from `run_snapshot_fleet`
- preserves the per-account snapshot behavior, env-var side effects, warning fallbacks, and JSON output shape
- adds a `// rationale:` comment to the surviving narrow `#[allow(clippy::large_enum_variant)]` on the clap command enum

## Issue #122 target audit
- `bin/tri-gardener/src/main.rs` no longer exists as a live crate target, so its old crate-level allow-list is already gone
- `crates/trios-railway-core/src/client_ext.rs` no longer exists, so its old `used_underscore_items` allow is already gone
- the remaining live allow was `#[allow(clippy::too_many_lines)]` on `run_snapshot_fleet`, not `run_service`; this PR removes it

## Tests
- Not run locally: this sandbox has no `cargo`, `rustc`, or `rustup` binary.
- Requires CI validation for `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, and `cargo test -p trios-railway-core`.

## Safety
- No SQL migrations changed.
- No live Railway or database mutations performed.

Refs #122.
