### PR TITLE
guard: enforce ADR-0042 SSOT pull-loop

### DIFF
--- a/.github/workflows/gardener-loop.yml
+++ b/.github/workflows/gardener-loop.yml
@@ -1,12 +1,20 @@
 name: GARDENER-LOOP — autonomous IGLA needle hunter (v2.12 · dual rate-collapse + v2.11 lift)
+
+# L-SS7 / ADR-0042: Sovereign Scarab v4 invariant.
+#   Scarabs pull ssot.scarab_strategy themselves; gardener MUST NOT push
+#   variableUpsert / serviceInstanceDeployV2 against the fleet anymore.
+#   The read-only probe stages (STAGE-0/0b/0d/1/1b/1c/2) are still useful
+#   for situational awareness, so the cron keeps running. Every push
+#   stage is gated on `LEGACY_PUSH_PATH_ENABLE == '1'`, which the cron
+#   never sets, so on schedule we always run read-only.
 on:
   schedule:
     - cron: "7,22,37,52 * * * *"  # каждые 15 минут — ночной режим 4x x
   workflow_dispatch:
     inputs:
       mode:
-        description: "review | live"
-        default: "live"
+        description: "review | live (live ignored — push path disabled per ADR-0042)"
+        default: "review"
 permissions:
   contents: write     # для auto-commit улучшений
   issues: write
@@ -16,6 +24,10 @@ jobs:
     runs-on: ubuntu-24.04
     env:
       RAILWAY_POSTGRES_URL: ${{ secrets.RAILWAY_POSTGRES_URL }}
+      # ADR-0042 LEGACY_PUSH_PATH_DISABLED. Push stages below check this
+      # env. Setting to "1" temporarily for an authorized operator-led
+      # repair is allowed; cron must never set it.
+      LEGACY_PUSH_PATH_ENABLE: "0"
       T1: ${{ secrets.RAILWAY_TOKEN_ACC1 }}
       T2: ${{ secrets.RAILWAY_TOKEN_ACC2 }}
       T3: ${{ secrets.RAILWAY_TOKEN_ACC3 }}
@@ -255,7 +267,9 @@ jobs:
           echo "📊 Fleet: $TOTAL total · $DEAD dead/idle"
 
       - name: STAGE-2b — autofix dead services (redeploy if MODE=live)
-        if: steps.fleet.outputs.fleet_dead != '0' && env.MODE == 'live'
+        # ADR-0042: scarab redeploy is forbidden — scarabs self-restart on
+        # ssot.scarab_strategy row change. Gated on LEGACY_PUSH_PATH_ENABLE.
+        if: steps.fleet.outputs.fleet_dead != '0' && env.MODE == 'live' && env.LEGACY_PUSH_PATH_ENABLE == '1'
         run: |
           set +e
           FIXED=0
@@ -285,7 +299,9 @@ jobs:
       # ─────────────────────────────────────────────────────────────
       - name: STAGE-2b2 — SSOT URL propagation (canonical aliases)
         id: ssot_prop
-        if: env.MODE == 'live'
+        # ADR-0042: variableUpsert on scarab fleet is forbidden. SSOT DSN
+        # is delivered via the scarab image template, not push-control.
+        if: env.MODE == 'live' && env.LEGACY_PUSH_PATH_ENABLE == '1'
         run: |
           set +e
           PROPAGATED=0
@@ -332,7 +348,10 @@ jobs:
       # ─────────────────────────────────────────────────────────────
       - name: STAGE-2c — env drift autofix (re-upsert if drifted)
         id: drift
-        if: env.MODE == 'live'
+        # ADR-0042: per-cell FORMAT/OPTIMIZER/CANON_NAME live in
+        # ssot.scarab_strategy. variableUpsert here would race the pull
+        # loop. Gated.
+        if: env.MODE == 'live' && env.LEGACY_PUSH_PATH_ENABLE == '1'
         run: |
           set +e
           DRIFTED=0
@@ -374,7 +393,9 @@ jobs:
       # ─────────────────────────────────────────────────────────────
       - name: STAGE-2e — STEPS=81000 fleet-wide autofix
         id: steps_fix
-        if: env.MODE == 'live'
+        # ADR-0042: STEPS now lives in ssot.scarab_strategy.steps. Push
+        # path retained for emergency operator use only.
+        if: env.MODE == 'live' && env.LEGACY_PUSH_PATH_ENABLE == '1'
         run: |
           set +e
           FIXED=0
@@ -477,7 +498,8 @@ jobs:
       # idempotency cooldown. Reads .trinity/gardener-brain.json revive_workflow.
       # ─────────────────────────────────────────────────────────────
       - name: STAGE-2f — TRINITY BRAIN per-lane revive
-        if: env.MODE == 'live' && steps.brain.outputs.brain_missing != 'true'
+        # ADR-0042: revive dispatches sibling push-workflows. Gated.
+        if: env.MODE == 'live' && steps.brain.outputs.brain_missing != 'true' && env.LEGACY_PUSH_PATH_ENABLE == '1'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           STALLED: ${{ steps.brain.outputs.lanes_stalled }}
@@ -585,7 +607,9 @@ jobs:
           echo "📢 Throne #264 low-util alert posted"
 
       - name: STAGE-2d — forced wake-up on writer stall
-        if: steps.stall.outputs.stalled == 'true' && env.MODE == 'live'
+        # ADR-0042: scarab redeploy is forbidden — strategy bump is the
+        # canonical way to wake a stalled cell.
+        if: steps.stall.outputs.stalled == 'true' && env.MODE == 'live' && env.LEGACY_PUSH_PATH_ENABLE == '1'
         run: |
           set +e
           WOKEN=0
@@ -633,7 +657,8 @@ jobs:
       # Idempotency: 1 dispatch per cycle per 60min via gh api filter (created_at).
       # ─────────────────────────────────────────────────────────────
       - name: STAGE-3b — auto-dispatch missing matrix cells (v2.13)
-        if: ${{ env.MODE == 'live' }}
+        # ADR-0042: dispatches push-workflows. Gated.
+        if: ${{ env.MODE == 'live' && env.LEGACY_PUSH_PATH_ENABLE == '1' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TODO_COUNT: ${{ steps.todo.outputs.todo }}

--- a/.github/workflows/redeploy-single.yml
+++ b/.github/workflows/redeploy-single.yml
@@ -1,10 +1,48 @@
-name: REDEPLOY-SINGLE — re-trigger a single Railway service deploy
+name: "[ADR-0042] REDEPLOY-SINGLE — disabled scarab push path"
+
+# ADR-0042 LEGACY_PUSH_PATH_DISABLED.
+#
+# Scarabs (matrix-runner / trainer / strategy services) are forever-live
+# on Railway. They pull ssot.scarab_strategy themselves and self-restart
+# on row change. Railway-side redeploy is NOT how scarab control is
+# exercised — that contract lives in the Queen-Hive MCP writer.
+#
+# This workflow used to push `serviceInstanceDeployV2` against an
+# arbitrary service id. It is now disabled by default and refuses to run
+# under any cron path (there is none) AND under any operator dispatch
+# unless TWO independent break-glass locks are simultaneously open:
+#
+#   1. Input    `confirm`                  == "PHI"
+#   2. Secret   LEGACY_PUSH_PATH_ENABLE     == "1"
+#
+# The secret lock means a workflow_dispatch click alone cannot push;
+# an administrator must first set the repository secret, which is a
+# deliberate, audit-trailed action. Operators MUST unset the secret
+# immediately after the recovery dispatch finishes.
+#
+# Even with both locks open, this surface is reserved for NON-scarab
+# operator infrastructure recovery (MCP, writer, Postgres sidecar).
+# Pushing it at a scarab service id is still a violation of the
+# invariant — there is no programmatic way to enforce that here, so the
+# operator carries that obligation.
 on:
   workflow_dispatch:
     inputs:
       account: { required: true, default: "ACC4" }
       service_id: { required: true }
       environment_id: { required: true }
+      confirm:
+        description: "Type PHI to attempt ADR-0042 break-glass (still gated by repo secret)."
+        required: true
+        default: ""
+
+permissions:
+  contents: read
+
+concurrency:
+  group: redeploy-single-adr0042
+  cancel-in-progress: false
+
 jobs:
   redeploy:
     runs-on: ubuntu-latest
@@ -12,11 +50,45 @@ jobs:
       T4: ${{ secrets.RAILWAY_TOKEN_ACC4 }}
       T5: ${{ secrets.RAILWAY_TOKEN_ACC5 }}
       T6: ${{ secrets.RAILWAY_TOKEN_ACC6 }}
+      # Routing the secret through env rather than referencing
+      # `secrets.*` directly inside an `if:` is the GitHub-Actions
+      # idiom for boolean gating on secret presence (R5).
+      PUSH_PATH_ENABLE: ${{ secrets.LEGACY_PUSH_PATH_ENABLE }}
     steps:
-      - name: redeploy
+      - name: ADR-0042 double-key guard
         run: |
+          set -euo pipefail
+          ERR=0
+          if [[ "${{ inputs.confirm }}" != "PHI" ]]; then
+            echo "::error::ADR-0042 lock 1 closed: confirm input must be exactly 'PHI'."
+            ERR=1
+          fi
+          if [[ "${PUSH_PATH_ENABLE:-}" != "1" ]]; then
+            echo "::error::ADR-0042 lock 2 closed: repo secret LEGACY_PUSH_PATH_ENABLE != '1'."
+            echo "::error::Scarab fleet control lives in ssot.scarab_strategy via the Queen-Hive MCP writer."
+            echo "::error::This workflow performs Railway push (serviceInstanceDeployV2) and is forbidden for scarab services."
+            echo "::error::To break glass for NON-scarab operator recovery:"
+            echo "::error::  1. Administrator sets the repo secret LEGACY_PUSH_PATH_ENABLE=1."
+            echo "::error::  2. Operator dispatches this workflow with confirm=PHI."
+            echo "::error::  3. Administrator unsets the secret immediately after the run."
+            ERR=1
+          fi
+          if [[ "${ERR}" -ne 0 ]]; then
+            echo "::error::See docs/ADR-0042-pull-loop.md. Aborting."
+            exit 1
+          fi
+          echo "Both ADR-0042 locks open. Proceeding under operator responsibility."
+          echo "Anchor: phi^2 + phi^-2 = 3."
+
+      - name: redeploy (break-glass — non-scarab only)
+        run: |
+          set -euo pipefail
           ACC="${{ inputs.account }}"
           N="${ACC#ACC}"; VAR="T$N"; TOK="${!VAR}"
+          if [[ -z "${TOK:-}" ]]; then
+            echo "::error::No RAILWAY_TOKEN_${ACC} secret set."
+            exit 2
+          fi
           SVC="${{ inputs.service_id }}"
           ENVI="${{ inputs.environment_id }}"
           echo "Triggering serviceInstanceDeployV2 for $ACC svc=$SVC env=$ENVI"
@@ -24,4 +96,5 @@ jobs:
             -H "Content-Type: application/json" -H "Project-Access-Token: $TOK" \
             -d "{\"query\":\"mutation { serviceInstanceDeployV2(serviceId:\\\"$SVC\\\", environmentId:\\\"$ENVI\\\") }\"}")
           echo "Response: $R"
-          echo "$R" | jq -e '.data.serviceInstanceDeployV2' > /dev/null && echo "✓ redeploy queued: $(echo $R | jq -r .data.serviceInstanceDeployV2)"
+          echo "$R" | jq -e '.data.serviceInstanceDeployV2' > /dev/null \
+            && echo "✓ redeploy queued: $(echo $R | jq -r .data.serviceInstanceDeployV2)"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,3 +65,26 @@ Agent: GENERAL
 - Touch `crates/trios-trainer-igla/*` — different repo entirely.
 - Open browsers (`R7` of `NOW.json`); use `gh` CLI and the Neon connector.
 - Hand-edit generated GraphQL response JSON; treat it as opaque bytes.
+
+## Scarab control invariant (ADR-0042)
+
+Scarabs (matrix-runner / trainer / strategy services) are **forever-live**
+on Railway. They pull `ssot.scarab_strategy WHERE service_id=$me` every N
+seconds and self-restart on row change. Control flows through the
+**Queen-Hive MCP writer** as `INSERT`/`UPDATE` against
+`ssot.scarab_strategy`, NOT through Railway GraphQL.
+
+Forbidden against the scarab fleet from this repo:
+
+- `variableUpsert` (env mutation)
+- `serviceInstanceDeployV2` / `serviceInstanceRedeploy`
+- `serviceInstanceUpdate` (image pin — DR template only)
+- `serviceDelete` (use SSOT `status='quarantine'` instead)
+
+The Rust write surface in `crates/trios-railway-core` and the
+`tri-railway service deploy/redeploy/delete` verbs are gated behind
+`LEGACY_PUSH_PATH_ENABLE=1`. CI / cron must never set that variable.
+Read-only diagnostics (audit watchdog, fleet snapshot, MCP diagnose)
+remain freely available.
+
+Full rationale: [`docs/ADR-0042-pull-loop.md`](docs/ADR-0042-pull-loop.md).

--- a/bin/tri-railway/src/main.rs
+++ b/bin/tri-railway/src/main.rs
@@ -520,6 +520,26 @@ async fn run_service(cmd: ServiceCmd) -> Result<()> {
         Client::from_env().map_err(|e| anyhow::anyhow!("RAILWAY_TOKEN not set or invalid: {e}"))?;
     let token_fp = client.token_fingerprint();
 
+    // ADR-0042: scarab fleet control is via ssot.scarab_strategy + Queen
+    // Hive, NOT via push mutations. The CLI write verbs are kept for
+    // MCP / writer / DR recovery; refuse to run unless the operator has
+    // explicitly opted in via LEGACY_PUSH_PATH_ENABLE=1.
+    let push_enabled = std::env::var("LEGACY_PUSH_PATH_ENABLE")
+        .map(|v| v == "1")
+        .unwrap_or(false);
+    if !push_enabled
+        && matches!(
+            cmd,
+            ServiceCmd::Deploy { .. } | ServiceCmd::Redeploy { .. } | ServiceCmd::Delete { .. }
+        )
+    {
+        anyhow::bail!(
+            "LEGACY_PUSH_PATH_DISABLED (ADR-0042): refusing scarab push mutation. \
+             Scarabs pull ssot.scarab_strategy themselves; use the Queen-Hive MCP writer. \
+             To override for non-scarab operator recovery, set LEGACY_PUSH_PATH_ENABLE=1."
+        );
+    }
+
     match cmd {
         ServiceCmd::List { project } => {
             let pid = ProjectId::from(project);

--- a/bin/tri-railway/src/main.rs
+++ b/bin/tri-railway/src/main.rs
@@ -515,30 +515,36 @@ fn parse_var(s: &str) -> Result<(String, String)> {
     Ok((k.to_string(), v.to_string()))
 }
 
+/// ADR-0042 guard: scarab fleet control lives in `ssot.scarab_strategy` via
+/// the Queen-Hive MCP writer, NOT in Railway push mutations. The CLI write
+/// verbs (`Deploy` / `Redeploy` / `Delete`) are retained for non-scarab
+/// operator recovery and refuse to run unless `LEGACY_PUSH_PATH_ENABLE=1`
+/// is set explicitly.
+fn ensure_push_path_allowed(cmd: &ServiceCmd) -> Result<()> {
+    let is_push = matches!(
+        cmd,
+        ServiceCmd::Deploy { .. } | ServiceCmd::Redeploy { .. } | ServiceCmd::Delete { .. }
+    );
+    if !is_push {
+        return Ok(());
+    }
+    let push_enabled = std::env::var("LEGACY_PUSH_PATH_ENABLE").is_ok_and(|v| v == "1");
+    if push_enabled {
+        return Ok(());
+    }
+    anyhow::bail!(
+        "LEGACY_PUSH_PATH_DISABLED (ADR-0042): refusing scarab push mutation. \
+         Scarabs pull ssot.scarab_strategy themselves; use the Queen-Hive MCP writer. \
+         To override for non-scarab operator recovery, set LEGACY_PUSH_PATH_ENABLE=1."
+    );
+}
+
 async fn run_service(cmd: ServiceCmd) -> Result<()> {
+    ensure_push_path_allowed(&cmd)?;
+
     let client =
         Client::from_env().map_err(|e| anyhow::anyhow!("RAILWAY_TOKEN not set or invalid: {e}"))?;
     let token_fp = client.token_fingerprint();
-
-    // ADR-0042: scarab fleet control is via ssot.scarab_strategy + Queen
-    // Hive, NOT via push mutations. The CLI write verbs are kept for
-    // MCP / writer / DR recovery; refuse to run unless the operator has
-    // explicitly opted in via LEGACY_PUSH_PATH_ENABLE=1.
-    let push_enabled = std::env::var("LEGACY_PUSH_PATH_ENABLE")
-        .map(|v| v == "1")
-        .unwrap_or(false);
-    if !push_enabled
-        && matches!(
-            cmd,
-            ServiceCmd::Deploy { .. } | ServiceCmd::Redeploy { .. } | ServiceCmd::Delete { .. }
-        )
-    {
-        anyhow::bail!(
-            "LEGACY_PUSH_PATH_DISABLED (ADR-0042): refusing scarab push mutation. \
-             Scarabs pull ssot.scarab_strategy themselves; use the Queen-Hive MCP writer. \
-             To override for non-scarab operator recovery, set LEGACY_PUSH_PATH_ENABLE=1."
-        );
-    }
 
     match cmd {
         ServiceCmd::List { project } => {

--- a/crates/trios-railway-mcp/src/tools.rs
+++ b/crates/trios-railway-mcp/src/tools.rs
@@ -212,6 +212,7 @@ impl TriosRailwayMcp {
         &self,
         Parameters(req): Parameters<DeployRequest>,
     ) -> Result<CallToolResult, McpError> {
+        check_push_path_allowed()?;
         let client = build_client()?;
         let token_fp = client.token_fingerprint();
 
@@ -285,6 +286,7 @@ impl TriosRailwayMcp {
         &self,
         Parameters(req): Parameters<RedeployRequest>,
     ) -> Result<CallToolResult, McpError> {
+        check_push_path_allowed()?;
         let client = build_client()?;
         let env = req
             .environment
@@ -310,6 +312,7 @@ impl TriosRailwayMcp {
         &self,
         Parameters(req): Parameters<DeleteRequest>,
     ) -> Result<CallToolResult, McpError> {
+        check_push_path_allowed()?;
         if !req.confirm {
             return Err(McpError::invalid_params(
                 "refusing to delete service without `confirm: true` (R9)".to_string(),
@@ -385,6 +388,7 @@ impl TriosRailwayMcp {
         &self,
         Parameters(req): Parameters<TemplateDeployRequest>,
     ) -> Result<CallToolResult, McpError> {
+        check_push_path_allowed()?;
         if req.seeds.is_empty() {
             return Err(McpError::invalid_params(
                 "seeds[] must contain at least one seed".to_string(),
@@ -650,6 +654,25 @@ fn build_client() -> Result<Client, McpError> {
     })
 }
 
+/// ADR-0042 guard: scarab fleet is controlled via ssot.scarab_strategy.
+/// MCP push tools refuse unless the operator opts in explicitly.
+fn check_push_path_allowed() -> Result<(), McpError> {
+    let on = std::env::var("LEGACY_PUSH_PATH_ENABLE")
+        .map(|v| v == "1")
+        .unwrap_or(false);
+    if on {
+        Ok(())
+    } else {
+        Err(McpError::invalid_params(
+            "LEGACY_PUSH_PATH_DISABLED (ADR-0042): scarab push mutations are forbidden. \
+             Use Queen-Hive MCP writer against ssot.scarab_strategy. \
+             To override for non-scarab operator recovery, set LEGACY_PUSH_PATH_ENABLE=1."
+                .to_string(),
+            None,
+        ))
+    }
+}
+
 fn kv(key: &str, value: &str) -> KeyValue {
     KeyValue {
         key: key.to_string(),
@@ -672,4 +695,39 @@ async fn find_service_by_name(
 
 fn internal_err<E: std::fmt::Display>(e: E) -> McpError {
     McpError::internal_error(e.to_string(), None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::check_push_path_allowed;
+
+    // ADR-0042: scarab push surface is disabled by default. Single test
+    // walks all cases sequentially so it cannot race other env-mutating
+    // tests in the same binary.
+    #[test]
+    fn legacy_push_path_guard_matrix() {
+        let prev = std::env::var("LEGACY_PUSH_PATH_ENABLE").ok();
+
+        // (a) unset → refuses
+        std::env::remove_var("LEGACY_PUSH_PATH_ENABLE");
+        assert!(check_push_path_allowed().is_err(), "unset must refuse");
+
+        // (b) "0" → refuses
+        std::env::set_var("LEGACY_PUSH_PATH_ENABLE", "0");
+        assert!(check_push_path_allowed().is_err(), "'0' must refuse");
+
+        // (c) "true"/"yes" do not count — only the literal "1" opts in.
+        std::env::set_var("LEGACY_PUSH_PATH_ENABLE", "true");
+        assert!(check_push_path_allowed().is_err(), "'true' must refuse");
+
+        // (d) "1" → allowed
+        std::env::set_var("LEGACY_PUSH_PATH_ENABLE", "1");
+        assert!(check_push_path_allowed().is_ok(), "'1' must allow");
+
+        // Restore prior state for any sibling test.
+        match prev {
+            Some(v) => std::env::set_var("LEGACY_PUSH_PATH_ENABLE", v),
+            None => std::env::remove_var("LEGACY_PUSH_PATH_ENABLE"),
+        }
+    }
 }

--- a/crates/trios-railway-mcp/src/tools.rs
+++ b/crates/trios-railway-mcp/src/tools.rs
@@ -654,12 +654,10 @@ fn build_client() -> Result<Client, McpError> {
     })
 }
 
-/// ADR-0042 guard: scarab fleet is controlled via ssot.scarab_strategy.
+/// ADR-0042 guard: scarab fleet is controlled via `ssot.scarab_strategy`.
 /// MCP push tools refuse unless the operator opts in explicitly.
 fn check_push_path_allowed() -> Result<(), McpError> {
-    let on = std::env::var("LEGACY_PUSH_PATH_ENABLE")
-        .map(|v| v == "1")
-        .unwrap_or(false);
+    let on = std::env::var("LEGACY_PUSH_PATH_ENABLE").is_ok_and(|v| v == "1");
     if on {
         Ok(())
     } else {

--- a/docs/ADR-0042-pull-loop.md
+++ b/docs/ADR-0042-pull-loop.md
@@ -1,0 +1,107 @@
+# ADR-0042 — Sovereign Scarab v4 Pull-Loop (SSOT invariant)
+
+Status: **ACCEPTED** (binding, 2026-05-17)
+Anchor: `phi^2 + phi^-2 = 3`
+
+## Invariant (hard)
+
+Scarabs (matrix-runner / trainer / strategy services) are **always live on Railway**:
+deploy once, forever. Their control plane is the Postgres SSOT table
+`ssot.scarab_strategy`, not Railway's GraphQL API.
+
+Every scarab implements a pull loop:
+
+```
+loop {
+    row = SELECT * FROM ssot.scarab_strategy WHERE service_id = $me;
+    apply(row.optimizer, row.format, row.hidden, row.lr, row.seed,
+          row.steps, row.status='active');
+    if (row changed since last tick) graceful_self_restart();
+    write_bpb_sample_to ssot.bpb_samples;
+    sleep N seconds;
+}
+```
+
+Control is exercised by Queen Hive (the operator/MCP) via `INSERT`/`UPDATE`
+into `ssot.scarab_strategy` through the writer MCP. The fleet converges in
+the next tick (typically ≤30 s) without any Railway-side action.
+
+## What is FORBIDDEN for scarab control
+
+The following Railway GraphQL operations **must not** be issued against the
+scarab fleet from this repo:
+
+- `variableUpsert` — env mutation is push-control; SSOT pull supersedes it.
+- `serviceInstanceUpdate` — image/source pin is template-only (DR restore),
+  not a steady-state control knob.
+- `serviceInstanceDeployV2` / `serviceInstanceRedeploy` — scarabs self-restart
+  on `ssot.scarab_strategy` row change; redeploy is never required for
+  strategy changes.
+- `serviceDelete` — scarabs are forever; quarantine via SSOT `status` column,
+  do not delete.
+
+Symbolic name for the legacy push surface: **`LEGACY_PUSH_PATH_DISABLED`**.
+
+## Token policies (defensive)
+
+- No new code path may read `RAILWAY_API_TOKEN`. Use the single
+  `RAILWAY_TOKEN` (or per-account `RAILWAY_TOKEN_ACC{N}`) only for the two
+  remaining authorized surfaces (see below).
+- `Authorization: Bearer` vs `Project-Access-Token` is auto-detected by
+  `crates/trios-railway-core/src/transport.rs`; do not hand-roll headers
+  in new code.
+
+## What is still PERMITTED
+
+The Rust crate `trios-railway-core` and the `tri-railway` binary expose
+Railway GraphQL because **two non-scarab surfaces** legitimately need it:
+
+1. **Read-only diagnostics** — `tri-railway service list`, audit watchdog,
+   fleet snapshot, MCP diagnose. These cannot violate the invariant.
+2. **MCP control-plane recovery** — `mcp-emergency-redeploy.yml` and
+   `writer-env-fix.yml` mutate the trios-railway-mcp / writer sidecar
+   services themselves, which are operator-tier infrastructure, not
+   scarabs. They are kept manual + `confirm == 'PHI'` guarded and are out
+   of scope of this ADR.
+3. **Disaster Recovery** — full-fleet recreation from
+   `disaster-recovery/fleet-snapshot.json` after an account ban.
+   Documented in `docs/DISASTER_RECOVERY.md` and `deploy-from-template.yml`.
+   DR exists precisely so that the steady-state pull loop can assume
+   "scarabs are forever".
+
+## Compatibility shims (kept for git history)
+
+Workflows that previously pushed env / redeploys to the scarab fleet are
+gated on `if: false` and emit an `::error::` pointing to this ADR when
+dispatched. They are kept (not deleted) so that historical CI runs remain
+linkable.
+
+The Rust mutation functions in `crates/trios-railway-core/src/mutations.rs`
+are still compiled and tested, but the operator-facing CLI verbs
+(`tri-railway service deploy / redeploy / delete`) check for
+`LEGACY_PUSH_PATH_ENABLE=1` and refuse otherwise. CI / cron must never
+set that env var.
+
+## Closed by this ADR
+
+- gHashTag/trios-railway#43, #114, #116 — old Railway MCP routes
+  (`railway_service_deploy / redeploy / delete`): keep handler, refuse at
+  runtime unless `LEGACY_PUSH_PATH_ENABLE=1` is set explicitly by an
+  operator.
+- gHashTag/trios-railway#126 — MCP telemetry env upsert + redeploy:
+  retained as `mcp-emergency-redeploy.yml` / `writer-env-fix.yml` because
+  they target the MCP / writer service (non-scarab), not the fleet.
+- gHashTag/trios-railway#137 — watchdog `Authorization` header: addressed
+  by `transport.rs` auto-detection; no scarab control path involved.
+
+## Verification
+
+```
+grep -rn 'variableUpsert\|serviceInstanceDeployV2\|serviceInstanceRedeploy\|serviceDelete' \
+    .github/workflows/ \
+  | grep -v 'L-SS7\|LEGACY_PUSH_PATH_DISABLED\|if: false\|deprecated'
+```
+
+Must return only the four allowlisted entry points:
+`mcp-emergency-redeploy.yml`, `writer-env-fix.yml`, `deploy-from-template.yml`,
+and the Rust core/MCP tool definitions guarded by `LEGACY_PUSH_PATH_ENABLE`.


### PR DESCRIPTION
## Summary

This PR codifies the Scarab SSOT-only pull-loop invariant as ADR-0042 and blocks active Railway push-path control for the scarab fleet.

Invariant:
- scarabs stay live on Railway after one deploy
- scarabs poll `ssot.scarab_strategy` for optimizer/format/hidden/lr/seed/steps/status
- strategy changes cause graceful self-restart and new training
- scarabs write BPB into `ssot.bpb_samples`
- Queen Hive controls strategies only via INSERT/UPDATE through the MCP writer
- no Railway API / PAT / `variableUpsert` fleet management path

## Changes

- Add `docs/ADR-0042-pull-loop.md` as the canonical hard invariant.
- Gate gardener push stages behind `LEGACY_PUSH_PATH_ENABLE == '1'`; default cron path stays review-only.
- Harden `redeploy-single.yml` to double-key break-glass only: `confirm=PHI` plus `secrets.LEGACY_PUSH_PATH_ENABLE == '1'`; no cron/push/PR/workflow_run/repository_dispatch trigger.
- Add CLI deploy/redeploy/delete guard in `bin/tri-railway`.
- Add MCP deploy/redeploy/delete/template deploy guard plus regression test.
- Document the invariant in `AGENTS.md`.

## Validation

- `git diff --cached --check`
- YAML parse for `.github/workflows/redeploy-single.yml` and `.github/workflows/gardener-loop.yml`
- `git ls-files --error-unmatch docs/ADR-0042-pull-loop.md`

Not run locally: Rust cargo tests, because this sandbox has no Rust toolchain. CI should run `cargo test -p trios-railway-mcp legacy_push_path_guard_matrix`.

## Notes

This PR intentionally does not close #43/#114/#116/#126/#137 yet. After CI is green and this merges, those issues can be closed with a reference to ADR-0042.
