### PR TITLE
guard: extend ADR-0042 to residual Railway push workflows

### DIFF
--- a/.github/workflows/deploy-from-template.yml
+++ b/.github/workflows/deploy-from-template.yml
@@ -6,7 +6,13 @@ name: DR Deploy from template
 # (template marketplace) and CLI path are documented in
 # docs/DISASTER_RECOVERY.md.
 #
-# Anchor: phi^2 + phi^-2 = 3.
+# ADR-0042 allowlisted: full-fleet recreation after an account ban. DR
+# exists precisely so that the steady-state pull loop can assume
+# "scarabs are forever". Double-key break-glass gate:
+#   1. Input    `confirm`                  == "PHI"
+#   2. Secret   LEGACY_PUSH_PATH_ENABLE     == "1"
+#
+# Anchor: phi^2 + phi^-2 = 3. See docs/ADR-0042-pull-loop.md.
 
 on:
   workflow_dispatch:
@@ -29,7 +35,6 @@ permissions:
 
 jobs:
   deploy:
-    if: ${{ inputs.confirm == 'PHI' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
@@ -40,8 +45,32 @@ jobs:
                        || inputs.account_alias == 'acc3' && secrets.RAILWAY_TOKEN_ACC3 || '' }}
       RAILWAY_TOKEN_AUTH: team
       RUST_LOG:        info
+      # ADR-0042 lock 2 routed through env for boolean-gating inside `run:`.
+      PUSH_PATH_ENABLE: ${{ secrets.LEGACY_PUSH_PATH_ENABLE }}
 
     steps:
+      - name: ADR-0042 double-key guard
+        run: |
+          set -euo pipefail
+          ERR=0
+          if [[ "${{ inputs.confirm }}" != "PHI" ]]; then
+            echo "::error::ADR-0042 lock 1 closed: confirm input must be exactly 'PHI' (got '${{ inputs.confirm }}')."
+            ERR=1
+          fi
+          if [[ "${PUSH_PATH_ENABLE:-}" != "1" ]]; then
+            echo "::error::ADR-0042 lock 2 closed: repo secret LEGACY_PUSH_PATH_ENABLE != '1'."
+            echo "::error::DR template deploy is allowlisted ONLY for full-fleet recreation after an account ban."
+            echo "::error::To break glass: administrator sets LEGACY_PUSH_PATH_ENABLE=1, operator dispatches with confirm=PHI,"
+            echo "::error::administrator unsets the secret immediately after the run."
+            ERR=1
+          fi
+          if [[ "${ERR}" -ne 0 ]]; then
+            echo "::error::See docs/ADR-0042-pull-loop.md. Aborting."
+            exit 2
+          fi
+          echo "Both ADR-0042 locks open. Proceeding under operator responsibility."
+          echo "Anchor: phi^2 + phi^-2 = 3."
+
       - name: Checkout
         uses: actions/checkout@v4
 

--- a/.github/workflows/kill-stale-waves.yml
+++ b/.github/workflows/kill-stale-waves.yml
@@ -1,4 +1,8 @@
-name: KILL-STALE-WAVES — free deployment slots for ARCH lanes
+name: "[ADR-0042 disabled] KILL-STALE-WAVES — free deployment slots for ARCH lanes"
+
+# ADR-0042 LEGACY_PUSH_PATH_DISABLED — scarab fleet push is forbidden.
+# Use ssot.scarab_strategy.status to quarantine. Do not delete or sleep scarabs.
+# See docs/ADR-0042-pull-loop.md.
 
 # v2 (2026-05-15): Railway's `deploymentStop` only stops SUCCESS deployments.
 # QUEUED/BUILDING/DEPLOYING/CRASHED states need `deploymentCancel` OR setting
@@ -25,8 +29,18 @@ on:
         default: "true"
 
 jobs:
+  adr0042-disabled:
+    name: "ADR-0042 — scarab push path disabled"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Refuse scarab fleet push
+        run: |
+          echo "::error::ADR-0042 LEGACY_PUSH_PATH_DISABLED — scarab serviceInstanceUpdate/deploymentCancel is forbidden."
+          echo "::error::Quarantine scarabs via ssot.scarab_strategy.status, not by Railway-side disable."
+          echo "::error::See docs/ADR-0042-pull-loop.md. Anchor: phi^2 + phi^-2 = 3."
+          exit 1
   kill-stale:
-    if: ${{ inputs.confirm == 'PHI' }}
+    if: false  # ADR-0042: scarab push path disabled — kept for git history only
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     env:

--- a/.github/workflows/mass-revive-strategy.yml
+++ b/.github/workflows/mass-revive-strategy.yml
@@ -3,6 +3,9 @@ name: "[DEPRECATED L-SS7] MASS-REVIVE-STRATEGY — replaced by Sovereign Scarab 
 # DEPRECATED 2026-05-16 by L-SS7 (gHashTag/trios#940).
 # Sovereign Scarab v4 reads ssot.scarab_strategy itself — push-revive no
 # longer needed. Use Queen-Hive MCP (crates/queen-hive-mcp) for control.
+#
+# ADR-0042 LEGACY_PUSH_PATH_DISABLED — kept for git history only.
+# See docs/ADR-0042-pull-loop.md.
 
 # AUTONOMOUS REVIVAL of the 18 strategy rows held by the queen-hive scheduler.
 # `ssot.scarab_strategy` lists (service_id, account, format, optimizer, hidden,

--- a/.github/workflows/mcp-emergency-redeploy.yml
+++ b/.github/workflows/mcp-emergency-redeploy.yml
@@ -1,14 +1,19 @@
 name: MCP emergency redeploy
 
-# Manually-dispatched recovery workflow for the trios-railway-mcp service
-# (db786a4b-5a79-4643-b915-e9184680cf97) when the deployed instance loses
-# its `RAILWAY_POSTGRES_URL` env or enters a crash-loop. Two GraphQL
-# mutations against backboard.railway.com:
+# ADR-0042 allowlisted: NON-SCARAB operator-tier recovery for the
+# trios-railway-mcp service. Two GraphQL mutations against
+# backboard.railway.com:
 #   1. variableUpsert  RAILWAY_POSTGRES_URL = phd-postgres-ssot DATABASE_URL
 #   2. serviceInstanceRedeploy on the latest deployment of the production env
 #
-# Guarded by a `confirm == 'PHI'` input so an accidental run-workflow click
-# can never re-deploy a Trinity-Queen-Hive service. Anchor: phi^2 + phi^-2 = 3.
+# Double-key break-glass under ADR-0042:
+#   1. Input    `confirm`                  == "PHI"
+#   2. Secret   LEGACY_PUSH_PATH_ENABLE     == "1"
+#
+# This surface is reserved for the MCP / writer / Postgres sidecar
+# (operator-tier infrastructure). Pushing at a scarab service id is
+# still a violation of the invariant — operator carries that obligation.
+# Anchor: phi^2 + phi^-2 = 3. See docs/ADR-0042-pull-loop.md.
 
 on:
   workflow_dispatch:
@@ -54,19 +59,35 @@ jobs:
       MCP_VARIABLE_NAME:    "RAILWAY_POSTGRES_URL"
       RAILWAY_TOKEN:        ${{ secrets.RAILWAY_TOKEN_ACC1 }}
       RAILWAY_TOKEN_AUTH:   team
+      # ADR-0042 lock 2 routed through env so we can boolean-gate inside `run:`.
+      PUSH_PATH_ENABLE:     ${{ secrets.LEGACY_PUSH_PATH_ENABLE }}
 
     steps:
-      - name: Guard — confirm == 'PHI'
+      - name: ADR-0042 double-key guard
         run: |
+          set -euo pipefail
+          ERR=0
           if [[ "${{ inputs.confirm }}" != "PHI" ]]; then
-            echo "::error::confirm input must be exactly 'PHI' (got '${{ inputs.confirm }}'). Aborting per Trinity safety guard."
-            exit 2
+            echo "::error::ADR-0042 lock 1 closed: confirm input must be exactly 'PHI' (got '${{ inputs.confirm }}')."
+            ERR=1
+          fi
+          if [[ "${PUSH_PATH_ENABLE:-}" != "1" ]]; then
+            echo "::error::ADR-0042 lock 2 closed: repo secret LEGACY_PUSH_PATH_ENABLE != '1'."
+            echo "::error::This surface is reserved for NON-SCARAB MCP / writer / Postgres recovery."
+            echo "::error::To break glass: administrator sets LEGACY_PUSH_PATH_ENABLE=1, operator dispatches with confirm=PHI,"
+            echo "::error::administrator unsets the secret immediately after the run."
+            ERR=1
           fi
           if [[ -z "${RAILWAY_TOKEN}" ]]; then
             echo "::error::secret RAILWAY_TOKEN_ACC1 is empty. Set it in repo secrets before running."
-            exit 3
+            ERR=1
           fi
-          echo "Guard cleared. Anchor: phi^2 + phi^-2 = 3."
+          if [[ "${ERR}" -ne 0 ]]; then
+            echo "::error::See docs/ADR-0042-pull-loop.md. Aborting."
+            exit 2
+          fi
+          echo "Both ADR-0042 locks open. Proceeding under operator responsibility."
+          echo "Anchor: phi^2 + phi^-2 = 3."
 
       - name: Probe Railway GraphQL auth
         run: |

--- a/.github/workflows/raise-smoke.yml
+++ b/.github/workflows/raise-smoke.yml
@@ -1,4 +1,7 @@
-name: L-RAISE-SMOKE-V2 — reconfigure existing service end-to-end
+name: "[ADR-0042 disabled] L-RAISE-SMOKE-V2 — reconfigure existing service end-to-end"
+
+# ADR-0042 LEGACY_PUSH_PATH_DISABLED — scarab fleet push is forbidden.
+# See docs/ADR-0042-pull-loop.md.
 on:
   workflow_dispatch:
     inputs:
@@ -7,7 +10,18 @@ on:
         required: true
         default: "scarab-gf16"
 jobs:
+  adr0042-disabled:
+    name: "ADR-0042 — scarab push path disabled"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Refuse scarab fleet push
+        run: |
+          echo "::error::ADR-0042 LEGACY_PUSH_PATH_DISABLED — scarab fleet variableUpsert+serviceInstanceDeployV2 is forbidden."
+          echo "::error::Scarabs pull ssot.scarab_strategy themselves. Update strategy via Queen-Hive MCP writer."
+          echo "::error::See docs/ADR-0042-pull-loop.md. Anchor: phi^2 + phi^-2 = 3."
+          exit 1
   raise:
+    if: false  # ADR-0042: scarab push path disabled — kept for git history only
     runs-on: ubuntu-24.04
     env:
       T1: ${{ secrets.RAILWAY_TOKEN_ACC1 }}

--- a/.github/workflows/refresh-acc47.yml
+++ b/.github/workflows/refresh-acc47.yml
@@ -1,4 +1,7 @@
-name: REFRESH-ACC47 — variableUpsert + redeploy on existing 111 services
+name: "[ADR-0042 disabled] REFRESH-ACC47 — variableUpsert + redeploy on existing 111 services"
+
+# ADR-0042 LEGACY_PUSH_PATH_DISABLED — scarab fleet push is forbidden.
+# See docs/ADR-0042-pull-loop.md.
 on:
   workflow_dispatch:
     inputs:
@@ -7,7 +10,18 @@ on:
         type: string
         default: "0"
 jobs:
+  adr0042-disabled:
+    name: "ADR-0042 — scarab push path disabled"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Refuse scarab fleet push
+        run: |
+          echo "::error::ADR-0042 LEGACY_PUSH_PATH_DISABLED — scarab fleet variableUpsert+serviceInstanceDeployV2 is forbidden."
+          echo "::error::Scarabs pull ssot.scarab_strategy themselves. Update strategy via Queen-Hive MCP writer."
+          echo "::error::See docs/ADR-0042-pull-loop.md. Anchor: phi^2 + phi^-2 = 3."
+          exit 1
   refresh:
+    if: false  # ADR-0042: scarab push path disabled — kept for git history only
     runs-on: ubuntu-24.04
     env:
       T4: ${{ secrets.RAILWAY_TOKEN_ACC4 }}

--- a/.github/workflows/sleep-nca-hybrid.yml
+++ b/.github/workflows/sleep-nca-hybrid.yml
@@ -1,8 +1,23 @@
-name: SLEEP-NCA-HYBRID — temporarily sleep NCA + HYBRID to free JEPA slot
+name: "[ADR-0042 disabled] SLEEP-NCA-HYBRID — temporarily sleep NCA + HYBRID to free JEPA slot"
+
+# ADR-0042 LEGACY_PUSH_PATH_DISABLED — scarab fleet push is forbidden.
+# Quarantine via ssot.scarab_strategy.status, not via Railway sleepApplication.
+# See docs/ADR-0042-pull-loop.md.
 on:
   workflow_dispatch:
 jobs:
+  adr0042-disabled:
+    name: "ADR-0042 — scarab push path disabled"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Refuse scarab fleet push
+        run: |
+          echo "::error::ADR-0042 LEGACY_PUSH_PATH_DISABLED — scarab serviceInstanceUpdate (sleepApplication) is forbidden."
+          echo "::error::Quarantine scarabs via ssot.scarab_strategy.status, not by Railway-side sleep."
+          echo "::error::See docs/ADR-0042-pull-loop.md. Anchor: phi^2 + phi^-2 = 3."
+          exit 1
   sleep:
+    if: false  # ADR-0042: scarab push path disabled — kept for git history only
     runs-on: ubuntu-latest
     env:
       T5: ${{ secrets.RAILWAY_TOKEN_ACC5 }}

--- a/.github/workflows/test-create-acc4.yml
+++ b/.github/workflows/test-create-acc4.yml
@@ -1,8 +1,25 @@
-name: TEST-CREATE-ACC4 — try different mutations
+name: "[ADR-0042 disabled] TEST-CREATE-ACC4 — try different mutations"
+
+# ADR-0042 LEGACY_PUSH_PATH_DISABLED — Railway-side scarab creation is
+# forbidden. Scarab provisioning belongs to the Queen-Hive MCP / DR
+# template, not to ad-hoc serviceCreate experimentation.
+# See docs/ADR-0042-pull-loop.md.
 on:
   workflow_dispatch:
 jobs:
+  adr0042-disabled:
+    name: "ADR-0042 — scarab push path disabled"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Refuse scarab fleet push
+        run: |
+          echo "::error::ADR-0042 LEGACY_PUSH_PATH_DISABLED — serviceCreate / templateDeployV2 on the scarab fleet is forbidden."
+          echo "::error::Use the DR template (deploy-from-template.yml under double-key) for full-fleet recreation,"
+          echo "::error::and the Queen-Hive MCP writer for strategy changes."
+          echo "::error::See docs/ADR-0042-pull-loop.md. Anchor: phi^2 + phi^-2 = 3."
+          exit 1
   test:
+    if: false  # ADR-0042: scarab push path disabled — kept for git history only
     runs-on: ubuntu-24.04
     env:
       T4: ${{ secrets.RAILWAY_TOKEN_ACC4 }}

--- a/.github/workflows/tier1-explore-acc13.yml
+++ b/.github/workflows/tier1-explore-acc13.yml
@@ -1,4 +1,7 @@
-name: TIER1-EXPLORE-ACC13 — 10 unexplored format families on ACC1+ACC3 scarab services
+name: "[ADR-0042 disabled] TIER1-EXPLORE-ACC13 — 10 unexplored format families on ACC1+ACC3 scarab services"
+
+# ADR-0042 LEGACY_PUSH_PATH_DISABLED — scarab fleet push is forbidden.
+# See docs/ADR-0042-pull-loop.md.
 
 # PASS-18 RECOVERY · Option A
 # Original `tier1-explore.yml` targets ACC4-7 wave-* services, but those have
@@ -42,8 +45,18 @@ on:
         default: "200000"
 
 jobs:
+  adr0042-disabled:
+    name: "ADR-0042 — scarab push path disabled"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Refuse scarab fleet push
+        run: |
+          echo "::error::ADR-0042 LEGACY_PUSH_PATH_DISABLED — scarab fleet variableUpsert+serviceInstanceDeployV2 is forbidden."
+          echo "::error::Scarabs pull ssot.scarab_strategy themselves. Update strategy via Queen-Hive MCP writer."
+          echo "::error::See docs/ADR-0042-pull-loop.md. Anchor: phi^2 + phi^-2 = 3."
+          exit 1
   explore:
-    if: ${{ inputs.confirm == 'PHI' }}
+    if: false  # ADR-0042: scarab push path disabled — kept for git history only
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     env:

--- a/.github/workflows/tier1-explore.yml
+++ b/.github/workflows/tier1-explore.yml
@@ -1,4 +1,7 @@
-name: TIER1-EXPLORE — 10 unexplored format families on ACC4-7
+name: "[ADR-0042 disabled] TIER1-EXPLORE — 10 unexplored format families on ACC4-7"
+
+# ADR-0042 LEGACY_PUSH_PATH_DISABLED — scarab fleet push is forbidden.
+# See docs/ADR-0042-pull-loop.md.
 
 # After 12/65 formats explored (gf256 champion 2.5719, posit16 second 2.6251,
 # fp16 third 2.6691), 53 formats remain unprobed. Operator-prioritised Tier-1
@@ -35,8 +38,18 @@ on:
         default: "200000"
 
 jobs:
+  adr0042-disabled:
+    name: "ADR-0042 — scarab push path disabled"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Refuse scarab fleet push
+        run: |
+          echo "::error::ADR-0042 LEGACY_PUSH_PATH_DISABLED — scarab fleet variableUpsert+serviceInstanceDeployV2 is forbidden."
+          echo "::error::Scarabs pull ssot.scarab_strategy themselves. Update strategy via Queen-Hive MCP writer."
+          echo "::error::See docs/ADR-0042-pull-loop.md. Anchor: phi^2 + phi^-2 = 3."
+          exit 1
   explore:
-    if: ${{ inputs.confirm == 'PHI' }}
+    if: false  # ADR-0042: scarab push path disabled — kept for git history only
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     env:

--- a/.github/workflows/tier2-explore-v2.yml
+++ b/.github/workflows/tier2-explore-v2.yml
@@ -1,4 +1,7 @@
-name: TIER2-EXPLORE-V2 — 14 PhD MATRIX missing measurable formats · HIDDEN=384 (R6 fix)
+name: "[ADR-0042 disabled] TIER2-EXPLORE-V2 — 14 PhD MATRIX missing measurable formats · HIDDEN=384 (R6 fix)"
+
+# ADR-0042 LEGACY_PUSH_PATH_DISABLED — scarab fleet push is forbidden.
+# See docs/ADR-0042-pull-loop.md.
 
 # V1 (tier2-explore.yml) deployed 14 slots with HIDDEN=128 — trainer crashed
 # with "HIDDEN_DIM: HIDDEN_DIM=128 < 256 forbidden (R6)". V2 fixes this and
@@ -44,8 +47,18 @@ on:
         default: "200000"
 
 jobs:
+  adr0042-disabled:
+    name: "ADR-0042 — scarab push path disabled"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Refuse scarab fleet push
+        run: |
+          echo "::error::ADR-0042 LEGACY_PUSH_PATH_DISABLED — scarab fleet variableUpsert+serviceInstanceDeployV2 is forbidden."
+          echo "::error::Scarabs pull ssot.scarab_strategy themselves. Update strategy via Queen-Hive MCP writer."
+          echo "::error::See docs/ADR-0042-pull-loop.md. Anchor: phi^2 + phi^-2 = 3."
+          exit 1
   explore:
-    if: ${{ inputs.confirm == 'PHI' }}
+    if: false  # ADR-0042: scarab push path disabled — kept for git history only
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     env:

--- a/.github/workflows/tier2-explore.yml
+++ b/.github/workflows/tier2-explore.yml
@@ -1,4 +1,7 @@
-name: TIER2-EXPLORE — 14 more unexplored format families on ACC4-7
+name: "[ADR-0042 disabled] TIER2-EXPLORE — 14 more unexplored format families on ACC4-7"
+
+# ADR-0042 LEGACY_PUSH_PATH_DISABLED — scarab fleet push is forbidden.
+# See docs/ADR-0042-pull-loop.md.
 
 # Builds on TIER1-EXPLORE (10 formats deployed 2026-05-15T06:49Z covering
 # gf{4,8,32,64}, posit{8,32}, mxfp{6,8}, nf8, lns8). With format CHECK now
@@ -41,8 +44,18 @@ on:
         default: "200000"
 
 jobs:
+  adr0042-disabled:
+    name: "ADR-0042 — scarab push path disabled"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Refuse scarab fleet push
+        run: |
+          echo "::error::ADR-0042 LEGACY_PUSH_PATH_DISABLED — scarab fleet variableUpsert+serviceInstanceDeployV2 is forbidden."
+          echo "::error::Scarabs pull ssot.scarab_strategy themselves. Update strategy via Queen-Hive MCP writer."
+          echo "::error::See docs/ADR-0042-pull-loop.md. Anchor: phi^2 + phi^-2 = 3."
+          exit 1
   explore:
-    if: ${{ inputs.confirm == 'PHI' }}
+    if: false  # ADR-0042: scarab push path disabled — kept for git history only
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     env:

--- a/.github/workflows/wave-a-deep-dispatch.yml
+++ b/.github/workflows/wave-a-deep-dispatch.yml
@@ -1,4 +1,7 @@
-name: WAVE-A-DEEP — h=384 champion-formats + FP-EXPANSION (fp8/posit/nf4)
+name: "[ADR-0042 disabled] WAVE-A-DEEP — h=384 champion-formats + FP-EXPANSION (fp8/posit/nf4)"
+
+# ADR-0042 LEGACY_PUSH_PATH_DISABLED — scarab fleet push is forbidden.
+# See docs/ADR-0042-pull-loop.md.
 # SAFE dispatch: targets cells 153-164 (12 new) → services 32-43 (idle scarab slots).
 # DOES NOT touch services 1-31 (which carry 6 active canons + reserve).
 # STEPS configurable (default 200000 = deep run), HIDDEN extracted from canon_name `h{N}`.
@@ -19,7 +22,18 @@ on:
         required: true
         default: "1597"
 jobs:
+  adr0042-disabled:
+    name: "ADR-0042 — scarab push path disabled"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Refuse scarab fleet push
+        run: |
+          echo "::error::ADR-0042 LEGACY_PUSH_PATH_DISABLED — scarab fleet variableUpsert+serviceInstanceDeployV2 is forbidden."
+          echo "::error::Scarabs pull ssot.scarab_strategy themselves. Update strategy via Queen-Hive MCP writer."
+          echo "::error::See docs/ADR-0042-pull-loop.md. Anchor: phi^2 + phi^-2 = 3."
+          exit 1
   dispatch_deep:
+    if: false  # ADR-0042: scarab push path disabled — kept for git history only
     runs-on: ubuntu-24.04
     env:
       T1: ${{ secrets.RAILWAY_TOKEN_ACC1 }}

--- a/.github/workflows/wave-a-dispatch.yml
+++ b/.github/workflows/wave-a-dispatch.yml
@@ -1,4 +1,11 @@
-name: WAVE-A — dispatch matrix cycle
+name: "[ADR-0042 disabled] WAVE-A — dispatch matrix cycle"
+
+# ADR-0042 LEGACY_PUSH_PATH_DISABLED. This workflow used to variableUpsert
+# + serviceInstanceDeployV2 the scarab fleet on Railway. Scarabs now pull
+# ssot.scarab_strategy themselves; push-control for the fleet is forbidden.
+# Strategy changes belong in ssot.scarab_strategy via the Queen-Hive MCP
+# writer, not here. See docs/ADR-0042-pull-loop.md.
+
 on:
   workflow_dispatch:
     inputs:
@@ -7,7 +14,18 @@ on:
         required: true
         default: "1"
 jobs:
+  adr0042-disabled:
+    name: "ADR-0042 — scarab push path disabled"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Refuse scarab fleet push
+        run: |
+          echo "::error::ADR-0042 LEGACY_PUSH_PATH_DISABLED — scarab fleet variableUpsert+serviceInstanceDeployV2 is forbidden."
+          echo "::error::Scarabs pull ssot.scarab_strategy themselves. Update strategy via Queen-Hive MCP writer."
+          echo "::error::See docs/ADR-0042-pull-loop.md. Anchor: phi^2 + phi^-2 = 3."
+          exit 1
   dispatch:
+    if: false  # ADR-0042: scarab push path disabled — kept for git history only
     runs-on: ubuntu-24.04
     env:
       T1: ${{ secrets.RAILWAY_TOKEN_ACC1 }}

--- a/.github/workflows/wave-a-expand.yml
+++ b/.github/workflows/wave-a-expand.yml
@@ -1,4 +1,7 @@
-name: WAVE-A-EXPAND — broaden LR×Hidden×Format frontier (8 new cells)
+name: "[ADR-0042 disabled] WAVE-A-EXPAND — broaden LR×Hidden×Format frontier (8 new cells)"
+
+# ADR-0042 LEGACY_PUSH_PATH_DISABLED — scarab fleet push is forbidden.
+# See docs/ADR-0042-pull-loop.md.
 # After PATCH-1 stabilised STEPS=200000 on champions and WAVE-NEXT-LR
 # probed LR ∈ {3e-4, 1e-3, 3e-3} on slots 2/3/24, the operator wants
 # zero idle workers. Deploy 8 more cells onto previously-low-yield
@@ -31,8 +34,18 @@ on:
         default: "200000"
 
 jobs:
+  adr0042-disabled:
+    name: "ADR-0042 — scarab push path disabled"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Refuse scarab fleet push
+        run: |
+          echo "::error::ADR-0042 LEGACY_PUSH_PATH_DISABLED — scarab fleet variableUpsert+serviceInstanceDeployV2 is forbidden."
+          echo "::error::Scarabs pull ssot.scarab_strategy themselves. Update strategy via Queen-Hive MCP writer."
+          echo "::error::See docs/ADR-0042-pull-loop.md. Anchor: phi^2 + phi^-2 = 3."
+          exit 1
   expand:
-    if: ${{ inputs.confirm == 'PHI' }}
+    if: false  # ADR-0042: scarab push path disabled — kept for git history only
     runs-on: ubuntu-24.04
     env:
       T1: ${{ secrets.RAILWAY_TOKEN_ACC1 }}

--- a/.github/workflows/wave-a-extend-revive.yml
+++ b/.github/workflows/wave-a-extend-revive.yml
@@ -1,4 +1,7 @@
-name: WAVE-A-EXTEND-REVIVE — push champions past 200k cap + revive dead EXPAND cells
+name: "[ADR-0042 disabled] WAVE-A-EXTEND-REVIVE — push champions past 200k cap + revive dead EXPAND cells"
+
+# ADR-0042 LEGACY_PUSH_PATH_DISABLED — scarab fleet push is forbidden.
+# See docs/ADR-0042-pull-loop.md.
 # After PATCH-1 stabilised STEPS=200000 on champions (BPB=2.571882 plateau)
 # and WAVE-EXPAND seeded 8 LR×Hidden×Format cells (all 8 died 40-58 min after deploy
 # at step=37k-55k, indicating Railway sleep policy / image issue / silent OOM),
@@ -30,8 +33,18 @@ on:
         default: "500000"
 
 jobs:
+  adr0042-disabled:
+    name: "ADR-0042 — scarab push path disabled"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Refuse scarab fleet push
+        run: |
+          echo "::error::ADR-0042 LEGACY_PUSH_PATH_DISABLED — scarab fleet variableUpsert+serviceInstanceDeployV2 is forbidden."
+          echo "::error::Scarabs pull ssot.scarab_strategy themselves. Update strategy via Queen-Hive MCP writer."
+          echo "::error::See docs/ADR-0042-pull-loop.md. Anchor: phi^2 + phi^-2 = 3."
+          exit 1
   extend-revive:
-    if: ${{ inputs.confirm == 'PHI' }}
+    if: false  # ADR-0042: scarab push path disabled — kept for git history only
     runs-on: ubuntu-24.04
     env:
       T1: ${{ secrets.RAILWAY_TOKEN_ACC1 }}

--- a/.github/workflows/wave-a-massive.yml
+++ b/.github/workflows/wave-a-massive.yml
@@ -1,8 +1,22 @@
-name: WAVE-A-MASSIVE — create 109 new services on ACC4-7 + dispatch
+name: "[ADR-0042 disabled] WAVE-A-MASSIVE — create 109 new services on ACC4-7 + dispatch"
+
+# ADR-0042 LEGACY_PUSH_PATH_DISABLED — scarab fleet push is forbidden.
+# See docs/ADR-0042-pull-loop.md.
 on:
   workflow_dispatch:
 jobs:
+  adr0042-disabled:
+    name: "ADR-0042 — scarab push path disabled"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Refuse scarab fleet push
+        run: |
+          echo "::error::ADR-0042 LEGACY_PUSH_PATH_DISABLED — scarab fleet variableUpsert+serviceInstanceDeployV2 is forbidden."
+          echo "::error::Scarabs pull ssot.scarab_strategy themselves. Update strategy via Queen-Hive MCP writer."
+          echo "::error::See docs/ADR-0042-pull-loop.md. Anchor: phi^2 + phi^-2 = 3."
+          exit 1
   massive:
+    if: false  # ADR-0042: scarab push path disabled — kept for git history only
     runs-on: ubuntu-24.04
     env:
       T4: ${{ secrets.RAILWAY_TOKEN_ACC4 }}

--- a/.github/workflows/wave-a-next-lr-sweep.yml
+++ b/.github/workflows/wave-a-next-lr-sweep.yml
@@ -1,4 +1,7 @@
-name: WAVE-A-NEXT-LR — LR sweep on champion config (gf256-h128-adamw)
+name: "[ADR-0042 disabled] WAVE-A-NEXT-LR — LR sweep on champion config (gf256-h128-adamw)"
+
+# ADR-0042 LEGACY_PUSH_PATH_DISABLED — scarab fleet push is forbidden.
+# See docs/ADR-0042-pull-loop.md.
 # Hypothesis: champion plateaued at BPB=2.5719 across {h128, h384, baseline, DEEP}
 # ⇒ ceiling is NOT depth-bound, it's LR-bound. Sweep LR ∈ {3e-4, 1e-3, 3e-3}
 # on the FROZEN champion config (gf256/h128/adamw/rng1597) using STEPS=200000
@@ -23,8 +26,18 @@ on:
         default: "200000"
 
 jobs:
+  adr0042-disabled:
+    name: "ADR-0042 — scarab push path disabled"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Refuse scarab fleet push
+        run: |
+          echo "::error::ADR-0042 LEGACY_PUSH_PATH_DISABLED — scarab fleet variableUpsert+serviceInstanceDeployV2 is forbidden."
+          echo "::error::Scarabs pull ssot.scarab_strategy themselves. Update strategy via Queen-Hive MCP writer."
+          echo "::error::See docs/ADR-0042-pull-loop.md. Anchor: phi^2 + phi^-2 = 3."
+          exit 1
   lrsweep:
-    if: ${{ inputs.confirm == 'PHI' }}
+    if: false  # ADR-0042: scarab push path disabled — kept for git history only
     runs-on: ubuntu-24.04
     env:
       T1: ${{ secrets.RAILWAY_TOKEN_ACC1 }}

--- a/.github/workflows/wave-a-patch1-steps200k.yml
+++ b/.github/workflows/wave-a-patch1-steps200k.yml
@@ -1,4 +1,7 @@
-name: WAVE-A-PATCH1 — force STEPS=200000 + TRIOS_STEPS=200000 on cells 153-170
+name: "[ADR-0042 disabled] WAVE-A-PATCH1 — force STEPS=200000 + TRIOS_STEPS=200000 on cells 153-170"
+
+# ADR-0042 LEGACY_PUSH_PATH_DISABLED — scarab fleet push is forbidden.
+# See docs/ADR-0042-pull-loop.md.
 # Re-deploy cells 153-170 (services 32-43 + services from rescue cells 165-170)
 # with BOTH STEPS and TRIOS_STEPS to defeat the silent-drop bug where finished
 # trainers hit step=81000 default. The Wave-33 alias-resolver lives in main
@@ -18,8 +21,18 @@ on:
         default: "200000"
 
 jobs:
+  adr0042-disabled:
+    name: "ADR-0042 — scarab push path disabled"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Refuse scarab fleet push
+        run: |
+          echo "::error::ADR-0042 LEGACY_PUSH_PATH_DISABLED — scarab fleet variableUpsert+serviceInstanceDeployV2 is forbidden."
+          echo "::error::Scarabs pull ssot.scarab_strategy themselves. Update strategy via Queen-Hive MCP writer."
+          echo "::error::See docs/ADR-0042-pull-loop.md. Anchor: phi^2 + phi^-2 = 3."
+          exit 1
   patch1:
-    if: ${{ inputs.confirm == 'PHI' }}
+    if: false  # ADR-0042: scarab push path disabled — kept for git history only
     runs-on: ubuntu-24.04
     env:
       T1: ${{ secrets.RAILWAY_TOKEN_ACC1 }}

--- a/.github/workflows/wave-a-rescue-dispatch.yml
+++ b/.github/workflows/wave-a-rescue-dispatch.yml
@@ -1,4 +1,7 @@
-name: WAVE-A-RESCUE — int4 rescue + posit16 multi-seed + gf256-h384 multi-seed
+name: "[ADR-0042 disabled] WAVE-A-RESCUE — int4 rescue + posit16 multi-seed + gf256-h384 multi-seed"
+
+# ADR-0042 LEGACY_PUSH_PATH_DISABLED — scarab fleet push is forbidden.
+# See docs/ADR-0042-pull-loop.md.
 # SAFE dispatch: cells 165-170 (6 new) → services 26-31 (idle ACC3 lion/prodigy/sf-lite slots).
 # Tracks all 3 fixes: int4 divergence escape via alt-seed, posit16 multi-seed validation, gf256-h384 multi-seed.
 # DOES NOT touch services 1-25 (active baseline) or 32-43 (DEEP+FP from earlier deploy).
@@ -15,7 +18,18 @@ on:
         required: true
         default: "0.0001"
 jobs:
+  adr0042-disabled:
+    name: "ADR-0042 — scarab push path disabled"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Refuse scarab fleet push
+        run: |
+          echo "::error::ADR-0042 LEGACY_PUSH_PATH_DISABLED — scarab fleet variableUpsert+serviceInstanceDeployV2 is forbidden."
+          echo "::error::Scarabs pull ssot.scarab_strategy themselves. Update strategy via Queen-Hive MCP writer."
+          echo "::error::See docs/ADR-0042-pull-loop.md. Anchor: phi^2 + phi^-2 = 3."
+          exit 1
   dispatch_rescue:
+    if: false  # ADR-0042: scarab push path disabled — kept for git history only
     runs-on: ubuntu-24.04
     env:
       T1: ${{ secrets.RAILWAY_TOKEN_ACC1 }}

--- a/.github/workflows/writer-env-fix.yml
+++ b/.github/workflows/writer-env-fix.yml
@@ -1,6 +1,17 @@
-name: Writer Env Fix (DATABASE_URL on matrix runners)
+name: Writer Env Fix (DATABASE_URL on MCP / writer sidecar)
 
 # Anchor: phi^2 + phi^-2 = 3 · DOI 10.5281/zenodo.19227877
+#
+# ADR-0042 allowlisted: NON-SCARAB MCP / writer / Postgres sidecar recovery
+# ONLY. Scarab fleet env push (variableUpsert on scarab-*/phase1-*/trios-train-*)
+# was removed from this workflow when ADR-0042 was accepted — scarabs read
+# DSN from ssot.scarab_strategy / pulled image template, not Railway-side env.
+#
+# Double-key break-glass under ADR-0042:
+#   1. Input    `confirm`                  == "PHI"
+#   2. Secret   LEGACY_PUSH_PATH_ENABLE     == "1"
+#
+# See docs/ADR-0042-pull-loop.md.
 #
 # Lane: L-WRITER-ENV-FIX (refs gHashTag/trios-railway#126, gHashTag/trios#446).
 #
@@ -50,12 +61,13 @@ concurrency:
 
 jobs:
   fix:
-    if: ${{ inputs.confirm == 'PHI' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
       TOKEN_ACC1: ${{ secrets.RAILWAY_TOKEN_ACC1 }}
       TOKEN_ACC2: ${{ secrets.RAILWAY_TOKEN_ACC2 }}
+      # ADR-0042 lock 2 routed through env for boolean-gating inside `run:`.
+      PUSH_PATH_ENABLE: ${{ secrets.LEGACY_PUSH_PATH_ENABLE }}
       RAILWAY_TOKEN_AUTH: project  # B-18 fix (2026-05-14): all ACC1..7 tokens are project-scoped (PAT), not team. Verified by token-classify.yml run 25846091578.
       # B-19 fix (2026-05-14): real project IDs verified by token-classify.yml
       # run 25846091578 — PAT/projectToken returned ACC1->IGLA RACE,
@@ -73,6 +85,28 @@ jobs:
       # service list and Postgres-service literal DATABASE_PUBLIC_URL.
 
     steps:
+      - name: ADR-0042 double-key guard
+        run: |
+          set -euo pipefail
+          ERR=0
+          if [[ "${{ inputs.confirm }}" != "PHI" ]]; then
+            echo "::error::ADR-0042 lock 1 closed: confirm input must be exactly 'PHI' (got '${{ inputs.confirm }}')."
+            ERR=1
+          fi
+          if [[ "${PUSH_PATH_ENABLE:-}" != "1" ]]; then
+            echo "::error::ADR-0042 lock 2 closed: repo secret LEGACY_PUSH_PATH_ENABLE != '1'."
+            echo "::error::This surface is reserved for NON-SCARAB MCP / writer / Postgres recovery."
+            echo "::error::To break glass: administrator sets LEGACY_PUSH_PATH_ENABLE=1, operator dispatches with confirm=PHI,"
+            echo "::error::administrator unsets the secret immediately after the run."
+            ERR=1
+          fi
+          if [[ "${ERR}" -ne 0 ]]; then
+            echo "::error::See docs/ADR-0042-pull-loop.md. Aborting."
+            exit 2
+          fi
+          echo "Both ADR-0042 locks open. Proceeding under operator responsibility."
+          echo "Anchor: phi^2 + phi^-2 = 3."
+
       - name: Sanity-check tokens
         run: |
           set -euo pipefail
@@ -116,9 +150,14 @@ jobs:
           # (scarab-*, phase1-*) → writer COMA 1014 min.
           # We now query Railway GraphQL for the live service list at
           # runtime, filtered to known writer prefixes.
-          # Excluded prefixes (regex): ^Postgres$|^trios$|^trios-railway$|^trios-mcp$|^TEST-
-          WRITER_PREFIX_REGEX: '^(scarab-|phase1-|trios-train-|trios-matrix-bot$|trios-postrun-)'
-          EXCLUDE_REGEX: '^(Postgres$|trios$|trios-railway$|trios-mcp$|TEST-)'
+          # ADR-0042: scarab-/phase1-/trios-train- prefixes are SCARABS — never
+          # target them here. The legacy regex (scarab-|phase1-|trios-train-)
+          # was a pre-ADR-0042 footgun. Writer-env-fix is allowlisted for the
+          # MCP / writer sidecar / Postgres-adjacent services only. The MCP
+          # service itself is patched in the dedicated "MCP last" block below,
+          # so this main loop should match nothing in steady state.
+          WRITER_PREFIX_REGEX: '^(trios-writer-|trios-mcp-sidecar-)'
+          EXCLUDE_REGEX: '^(Postgres$|trios$|trios-railway$|trios-mcp$|trios-railway-mcp$|TEST-|scarab-|phase1-|trios-train-)'
         run: |
           set -uo pipefail
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,4 +87,21 @@ The Rust write surface in `crates/trios-railway-core` and the
 Read-only diagnostics (audit watchdog, fleet snapshot, MCP diagnose)
 remain freely available.
 
+`.github/workflows/` invariants (enforced by
+`trios-railway-audit::workflows`):
+
+- Every workflow that uses a Railway push mutation is either:
+  - **hard-disabled** with a refuse-job (legacy scarab fleet push —
+    `[ADR-0042 disabled]` prefix on the workflow `name:`), or
+  - **step-gated** by `env.LEGACY_PUSH_PATH_ENABLE == '1'` (only
+    `gardener-loop.yml`; cron path stays read-only), or
+  - **double-key gated** with input `confirm == 'PHI'` AND repo secret
+    `LEGACY_PUSH_PATH_ENABLE == '1'` (operator-tier recovery only:
+    `mcp-emergency-redeploy.yml`, `writer-env-fix.yml`,
+    `deploy-from-template.yml`, `redeploy-single.yml`).
+- No `schedule:`, `push:`, `pull_request:`, `workflow_run:`, or
+  `repository_dispatch:` trigger may reach a push-mutation workflow
+  (the gardener schedule is the lone exception and only fires
+  read-only stages).
+
 Full rationale: [`docs/ADR-0042-pull-loop.md`](docs/ADR-0042-pull-loop.md).

--- a/crates/trios-railway-audit/src/lib.rs
+++ b/crates/trios-railway-audit/src/lib.rs
@@ -14,6 +14,7 @@
 
 pub mod event;
 pub mod migrations;
+pub mod workflows;
 
 use serde::{Deserialize, Serialize};
 use trios_railway_core::ServiceId;

--- a/crates/trios-railway-audit/src/workflows.rs
+++ b/crates/trios-railway-audit/src/workflows.rs
@@ -1,12 +1,12 @@
 //! ADR-0042 text-level regression guard for GitHub Actions workflows.
 //!
-//! Scarab fleet push (variableUpsert / serviceInstanceDeployV2 /
-//! serviceInstanceRedeploy / serviceDelete / serviceInstanceUpdate) must
-//! not be reachable from `schedule`, `push`, `pull_request`, `workflow_run`,
-//! or `repository_dispatch` triggers. Every workflow that issues those
-//! GraphQL mutations must either be hard-disabled (legacy scarab fleet
-//! push) or double-key gated (operator-tier recovery: confirm=PHI plus
-//! repo secret LEGACY_PUSH_PATH_ENABLE=1).
+//! Scarab fleet push (`variableUpsert` / `serviceInstanceDeployV2` /
+//! `serviceInstanceRedeploy` / `serviceDelete` / `serviceInstanceUpdate`)
+//! must not be reachable from `schedule`, `push`, `pull_request`,
+//! `workflow_run`, or `repository_dispatch` triggers. Every workflow that
+//! issues those GraphQL mutations must either be hard-disabled (legacy
+//! scarab fleet push) or double-key gated (operator-tier recovery:
+//! `confirm=PHI` plus repo secret `LEGACY_PUSH_PATH_ENABLE=1`).
 //!
 //! These are text-level invariants only — they fire under `cargo test` and
 //! prevent silent drift; they do not replace operator review.

--- a/crates/trios-railway-audit/src/workflows.rs
+++ b/crates/trios-railway-audit/src/workflows.rs
@@ -44,7 +44,10 @@ mod tests {
             let body = fs::read_to_string(&path).expect("read workflow");
             out.insert(name, body);
         }
-        assert!(!out.is_empty(), "no workflows found under .github/workflows");
+        assert!(
+            !out.is_empty(),
+            "no workflows found under .github/workflows"
+        );
         out
     }
 
@@ -54,6 +57,8 @@ mod tests {
         "serviceInstanceRedeploy",
         "serviceDelete",
         "serviceInstanceUpdate",
+        "serviceCreate",
+        "templateDeployV2",
     ];
 
     fn has_push_mutation(body: &str) -> bool {
@@ -87,8 +92,7 @@ mod tests {
         let has_marker = body.contains("[ADR-0042 disabled]")
             || body.contains("[DEPRECATED L-SS7]")
             || body.contains("adr0042-disabled");
-        let has_block_job = body.contains("LEGACY_PUSH_PATH_DISABLED")
-            && body.contains("exit 1");
+        let has_block_job = body.contains("LEGACY_PUSH_PATH_DISABLED") && body.contains("exit 1");
         let has_if_false_on_push_job = body.contains("if: false");
         has_marker && (has_block_job || has_if_false_on_push_job)
     }
@@ -189,7 +193,12 @@ mod tests {
             "gardener-loop must keep its push-stage gates (expected >= 5, got {gated_steps})"
         );
 
-        let forbidden_triggers = ["push:", "pull_request:", "workflow_run:", "repository_dispatch:"];
+        let forbidden_triggers = [
+            "push:",
+            "pull_request:",
+            "workflow_run:",
+            "repository_dispatch:",
+        ];
         for (name, body) in &workflows {
             if !has_push_mutation(body) {
                 continue;

--- a/crates/trios-railway-audit/src/workflows.rs
+++ b/crates/trios-railway-audit/src/workflows.rs
@@ -1,0 +1,237 @@
+//! ADR-0042 text-level regression guard for GitHub Actions workflows.
+//!
+//! Scarab fleet push (variableUpsert / serviceInstanceDeployV2 /
+//! serviceInstanceRedeploy / serviceDelete / serviceInstanceUpdate) must
+//! not be reachable from `schedule`, `push`, `pull_request`, `workflow_run`,
+//! or `repository_dispatch` triggers. Every workflow that issues those
+//! GraphQL mutations must either be hard-disabled (legacy scarab fleet
+//! push) or double-key gated (operator-tier recovery: confirm=PHI plus
+//! repo secret LEGACY_PUSH_PATH_ENABLE=1).
+//!
+//! These are text-level invariants only — they fire under `cargo test` and
+//! prevent silent drift; they do not replace operator review.
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+    use std::fs;
+    use std::path::{Path, PathBuf};
+
+    fn workflows_dir() -> PathBuf {
+        // CARGO_MANIFEST_DIR = crates/trios-railway-audit
+        let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        manifest
+            .parent()
+            .and_then(Path::parent)
+            .expect("workspace root")
+            .join(".github/workflows")
+    }
+
+    fn read_workflows() -> BTreeMap<String, String> {
+        let dir = workflows_dir();
+        let mut out = BTreeMap::new();
+        for entry in fs::read_dir(&dir).expect("read .github/workflows") {
+            let entry = entry.expect("dir entry");
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("yml") {
+                continue;
+            }
+            let name = path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .expect("file name")
+                .to_string();
+            let body = fs::read_to_string(&path).expect("read workflow");
+            out.insert(name, body);
+        }
+        assert!(!out.is_empty(), "no workflows found under .github/workflows");
+        out
+    }
+
+    const PUSH_MUTATIONS: &[&str] = &[
+        "variableUpsert",
+        "serviceInstanceDeployV2",
+        "serviceInstanceRedeploy",
+        "serviceDelete",
+        "serviceInstanceUpdate",
+    ];
+
+    fn has_push_mutation(body: &str) -> bool {
+        PUSH_MUTATIONS.iter().any(|m| body.contains(m))
+    }
+
+    /// Workflows that legitimately exercise Railway push for NON-scarab
+    /// operator recovery. Each must carry the ADR-0042 double-key gate
+    /// (input `confirm=PHI` plus secret `LEGACY_PUSH_PATH_ENABLE=1`).
+    const OPERATOR_RECOVERY_ALLOWLIST: &[&str] = &[
+        "mcp-emergency-redeploy.yml",
+        "writer-env-fix.yml",
+        "deploy-from-template.yml",
+        // redeploy-single is the canonical PR-#219 break-glass form.
+        "redeploy-single.yml",
+    ];
+
+    /// Workflows whose push stages are gated by `LEGACY_PUSH_PATH_ENABLE`
+    /// at the *step* level (cron is read-only, dispatch stays review-only
+    /// by default). This is the gardener pattern from PR #219.
+    const STEP_GATED_ALLOWLIST: &[&str] = &["gardener-loop.yml"];
+
+    /// ADR-0042 §"Closed by this ADR" mentions that the Rust mutation
+    /// functions are still compiled. The corresponding workflows that
+    /// have been DEPRECATED by `if: false` + a refusing-`exit 1` job
+    /// keep the file for git history. These are recognised by the
+    /// presence of an `adr0042-disabled` or `[DEPRECATED L-SS7]` /
+    /// `[ADR-0042 disabled]` marker.
+    fn is_hard_disabled(name: &str, body: &str) -> bool {
+        let _ = name;
+        let has_marker = body.contains("[ADR-0042 disabled]")
+            || body.contains("[DEPRECATED L-SS7]")
+            || body.contains("adr0042-disabled");
+        let has_block_job = body.contains("LEGACY_PUSH_PATH_DISABLED")
+            && body.contains("exit 1");
+        let has_if_false_on_push_job = body.contains("if: false");
+        has_marker && (has_block_job || has_if_false_on_push_job)
+    }
+
+    /// A workflow with push mutations is classified into one of three
+    /// buckets. Anything not in a bucket is a regression.
+    enum Bucket {
+        OperatorRecovery,
+        StepGated,
+        HardDisabled,
+        Unclassified,
+    }
+
+    fn classify(name: &str, body: &str) -> Bucket {
+        if OPERATOR_RECOVERY_ALLOWLIST.contains(&name) {
+            return Bucket::OperatorRecovery;
+        }
+        if STEP_GATED_ALLOWLIST.contains(&name) {
+            return Bucket::StepGated;
+        }
+        if is_hard_disabled(name, body) {
+            return Bucket::HardDisabled;
+        }
+        Bucket::Unclassified
+    }
+
+    /// Every workflow that contains a Railway push mutation must be
+    /// classified into one of the three approved buckets.
+    #[test]
+    fn every_push_workflow_is_classified() {
+        let workflows = read_workflows();
+        let mut unclassified = Vec::new();
+        for (name, body) in &workflows {
+            if !has_push_mutation(body) {
+                continue;
+            }
+            if let Bucket::Unclassified = classify(name, body) {
+                unclassified.push(name.clone());
+            }
+        }
+        assert!(
+            unclassified.is_empty(),
+            "ADR-0042 regression: workflows with Railway push mutations are \
+             not classified (must be hard-disabled, step-gated, or \
+             operator-recovery double-keyed): {unclassified:?}"
+        );
+    }
+
+    /// Operator-recovery workflows must enforce BOTH `confirm == 'PHI'`
+    /// (input) AND `LEGACY_PUSH_PATH_ENABLE == '1'` (secret) before any
+    /// push mutation runs.
+    #[test]
+    fn operator_recovery_workflows_are_double_keyed() {
+        let workflows = read_workflows();
+        for name in OPERATOR_RECOVERY_ALLOWLIST {
+            let body = workflows
+                .get(*name)
+                .unwrap_or_else(|| panic!("missing workflow {name}"));
+            assert!(
+                body.contains("ADR-0042"),
+                "{name}: must reference ADR-0042 in workflow header/comment"
+            );
+            // The double-key guard step does an inverted check
+            // `[[ "${{ inputs.confirm }}" != "PHI" ]]` to refuse early —
+            // assert that the negation form appears in a `run:` step.
+            assert!(
+                body.contains("inputs.confirm")
+                    && (body.contains("!= \"PHI\"") || body.contains("!= 'PHI'")),
+                "{name}: must refuse when inputs.confirm != 'PHI'"
+            );
+            assert!(
+                body.contains("LEGACY_PUSH_PATH_ENABLE"),
+                "{name}: must require the LEGACY_PUSH_PATH_ENABLE second key"
+            );
+        }
+    }
+
+    /// No workflow that contains push mutations may be reachable from
+    /// `schedule`, `push`, `pull_request`, `workflow_run`, or
+    /// `repository_dispatch` triggers. The only triggers allowed are
+    /// `workflow_dispatch` (manual) — the gardener-loop schedule is
+    /// permitted because its push stages are step-gated and the cron
+    /// path never sets the enable env.
+    #[test]
+    fn no_push_mutation_workflow_has_automatic_trigger() {
+        let workflows = read_workflows();
+        // gardener-loop runs on schedule but every push step is gated on
+        // `env.LEGACY_PUSH_PATH_ENABLE == '1'`, which cron never sets.
+        // Verify that pattern is intact.
+        let gardener = workflows
+            .get("gardener-loop.yml")
+            .expect("gardener-loop.yml must exist");
+        let gated_steps = gardener
+            .matches("env.LEGACY_PUSH_PATH_ENABLE == '1'")
+            .count();
+        assert!(
+            gated_steps >= 5,
+            "gardener-loop must keep its push-stage gates (expected >= 5, got {gated_steps})"
+        );
+
+        let forbidden_triggers = ["push:", "pull_request:", "workflow_run:", "repository_dispatch:"];
+        for (name, body) in &workflows {
+            if !has_push_mutation(body) {
+                continue;
+            }
+            for trig in &forbidden_triggers {
+                assert!(
+                    !body.contains(trig),
+                    "{name}: push-mutation workflow must not declare an automatic '{trig}' trigger"
+                );
+            }
+            // schedule: is only allowed on gardener-loop (step-gated).
+            if name != "gardener-loop.yml" {
+                assert!(
+                    !body.contains("schedule:"),
+                    "{name}: only gardener-loop.yml may carry a schedule trigger \
+                     (push stages must be step-gated); see ADR-0042"
+                );
+            }
+        }
+    }
+
+    /// Workflows in the hard-disabled bucket must emit an explicit
+    /// `exit 1` refuse-step so a `workflow_dispatch` click cannot
+    /// silently no-op into a SUCCESS run.
+    #[test]
+    fn hard_disabled_workflows_refuse_explicitly() {
+        let workflows = read_workflows();
+        for (name, body) in &workflows {
+            if !has_push_mutation(body) {
+                continue;
+            }
+            if !matches!(classify(name, body), Bucket::HardDisabled) {
+                continue;
+            }
+            assert!(
+                body.contains("exit 1"),
+                "{name}: hard-disabled workflow must `exit 1` from a refuse-step"
+            );
+            assert!(
+                body.contains("ADR-0042"),
+                "{name}: hard-disabled workflow must reference ADR-0042"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

PR #219 codified ADR-0042 and locked down `gardener-loop.yml` + `redeploy-single.yml`. This PR finishes the audit: every remaining workflow that issues a Railway push mutation (`variableUpsert` / `serviceInstanceDeployV2` / `serviceInstanceRedeploy` / `serviceDelete` / `serviceInstanceUpdate`) is now classified into one of three approved buckets, with text-level regression guards to prevent silent drift.

Invariant: scarabs are forever-live and converge on `ssot.scarab_strategy` row changes. Railway push is forbidden for the scarab fleet. No `schedule`, `push`, `pull_request`, `workflow_run`, or `repository_dispatch` trigger may reach a push-mutation workflow.

## Changes

### Scarab-fleet workflows — hard-disabled

Refuse-job emits `::error::` and `exit 1`; the existing push job is gated by `if: false`. Files retained for git history.

- `kill-stale-waves.yml`
- `raise-smoke.yml`
- `refresh-acc47.yml`
- `sleep-nca-hybrid.yml`
- `tier1-explore.yml`, `tier1-explore-acc13.yml`
- `tier2-explore.yml`, `tier2-explore-v2.yml`
- `wave-a-dispatch.yml`, `wave-a-deep-dispatch.yml`, `wave-a-expand.yml`, `wave-a-extend-revive.yml`, `wave-a-massive.yml`, `wave-a-next-lr-sweep.yml`, `wave-a-patch1-steps200k.yml`, `wave-a-rescue-dispatch.yml`
- `mass-revive-strategy.yml` — ADR-0042 reference added to its existing L-SS7 deprecation header.

### Non-scarab operator recovery — double-key gate

Both `inputs.confirm == 'PHI'` AND repo secret `LEGACY_PUSH_PATH_ENABLE == '1'` required (the secret routes through `env:` so an `if:` boolean check at run-step level is reliable).

- `mcp-emergency-redeploy.yml`
- `writer-env-fix.yml` — also narrows the `WRITER_PREFIX_REGEX` from `^(scarab-|phase1-|trios-train-|...)` to `^(trios-writer-|trios-mcp-sidecar-)`. The legacy regex was a footgun that could push scarab env under operator authority; ADR-0042 §"What is still PERMITTED" reserves this workflow for the MCP / writer sidecar only.
- `deploy-from-template.yml` (DR restore).

### Regression test

`crates/trios-railway-audit/src/workflows.rs` adds four `#[cfg(test)]` invariants:

1. `every_push_workflow_is_classified` — any workflow that contains a push mutation must be in the operator-recovery allowlist, the step-gated allowlist, or marked hard-disabled with a refuse-job.
2. `operator_recovery_workflows_are_double_keyed` — each must reference ADR-0042, refuse when `inputs.confirm != 'PHI'`, AND check `LEGACY_PUSH_PATH_ENABLE`.
3. `no_push_mutation_workflow_has_automatic_trigger` — no `push:` / `pull_request:` / `workflow_run:` / `repository_dispatch:` on any push-mutation workflow; only `gardener-loop.yml` may carry `schedule:` (PR #219's step gates are checked here too — ≥5 occurrences of `env.LEGACY_PUSH_PATH_ENABLE == '1'`).
4. `hard_disabled_workflows_refuse_explicitly` — every hard-disabled workflow must `exit 1` and reference ADR-0042.

### Docs

`AGENTS.md` adds a `.github/workflows/` invariants block enumerating the three buckets and which file falls into which.

## Validation

- All 47 workflow YAML files parse cleanly via `python3 -c 'import yaml; yaml.safe_load(open(f))'`.
- A Python simulator of the Rust regression test reports 0 errors across the 23 workflows that contain push mutations (16 hard-disabled, 4 operator-recovery double-keyed, 1 step-gated, 2 already-deprecated `mass-deploy-arch` / `mass-revive-strategy`).
- Rust toolchain not available in this sandbox — CI must run `cargo test -p trios-railway-audit workflows::tests`.
- PR #219 gates left intact: `gardener-loop.yml` still has 7 `env.LEGACY_PUSH_PATH_ENABLE == '1'` stage gates; `redeploy-single.yml` still has its double-key guard.

## Remaining risks

- The regression test is text-level, not semantic. A hostile rewrite that keeps the magic strings but routes around them (e.g. inline a curl mutation without the GraphQL field name in plain text) would not be caught. ADR-0042 §Verification's grep was already in this category — combine with code review.
- `LEGACY_PUSH_PATH_ENABLE` is a *repo* secret, not an *environment* secret. If GitHub envs become available, prefer them for an audit trail.
- The break-glass procedure for operator recovery (admin sets secret → operator dispatches → admin unsets secret) is documented in the workflow comments but not enforced by GitHub. Operator discipline carries that obligation.

Anchor: phi^2 + phi^-2 = 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)