### PR TITLE
fix(scarab): publish sovereign-scarab image so ADR-0042 runtime reaches Railway

### DIFF
--- a/.github/workflows/sovereign-scarab.yml
+++ b/.github/workflows/sovereign-scarab.yml
@@ -1,0 +1,77 @@
+name: sovereign-scarab
+
+# Publish ghcr.io/<owner>/sovereign-scarab from crates/trios-igla-race
+# (Dockerfile.scarab, ADR-0042 SSOT pull-loop runtime). Without this
+# workflow the merged ADR-0042 fix in src/bin/scarab.rs never reaches
+# Railway: scarab services are deployed from this image tag and there
+# was previously no CI path that built it.
+#
+# Read-only with respect to Railway: this workflow only writes to GHCR;
+# it never calls Railway GraphQL push mutations. Triggering a redeploy
+# remains an operator action (the scarab control plane is SSOT, not
+# Railway API — ADR-0042).
+#
+# Anchor: phi^2 + phi^-2 = 3.
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "crates/trios-igla-race/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/sovereign-scarab.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Lowercase repo owner
+        id: owner
+        run: |
+          echo "value=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute tags
+        id: tags
+        run: |
+          set -euo pipefail
+          OWNER='${{ steps.owner.outputs.value }}'
+          IMG="ghcr.io/${OWNER}/sovereign-scarab"
+          SHA='${{ github.sha }}'
+          SHORT="${SHA:0:7}"
+          REF='${{ github.ref_name }}'
+          REF_SAFE=$(echo "${REF}" | tr '/' '-')
+          {
+            echo "image=${IMG}"
+            echo "sha=${SHORT}"
+            echo "ref=${REF_SAFE}"
+          } >> "$GITHUB_OUTPUT"
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: crates/trios-igla-race/Dockerfile.scarab
+          push: true
+          tags: |
+            ${{ steps.tags.outputs.image }}:latest
+            ${{ steps.tags.outputs.image }}:v4
+            ${{ steps.tags.outputs.image }}:${{ steps.tags.outputs.sha }}
+            ${{ steps.tags.outputs.image }}:${{ steps.tags.outputs.ref }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/crates/trios-igla-race/tests/scarab_runtime_invariants.rs
+++ b/crates/trios-igla-race/tests/scarab_runtime_invariants.rs
@@ -176,8 +176,7 @@ fn sovereign_scarab_workflow() -> String {
 fn scarab_dockerfile_builds_adr0042_scarab_bin() {
     let dockerfile = scarab_dockerfile();
     assert!(
-        dockerfile.contains("--bin scarab")
-            && dockerfile.contains("-p trios-igla-race"),
+        dockerfile.contains("--bin scarab") && dockerfile.contains("-p trios-igla-race"),
         "Dockerfile.scarab must build `--bin scarab -p trios-igla-race`; \
          got:\n{dockerfile}"
     );
@@ -249,10 +248,7 @@ fn sovereign_scarab_publish_workflow_exists_and_targets_scarab_dockerfile() {
     );
     // The workflow must NOT reuse the MCP Dockerfile or other legacy
     // Dockerfiles — that would publish the wrong runtime.
-    for wrong in [
-        "Dockerfile.mcp",
-        "Dockerfile.real-seed-agent",
-    ] {
+    for wrong in ["Dockerfile.mcp", "Dockerfile.real-seed-agent"] {
         assert!(
             !wf.contains(wrong),
             "sovereign-scarab.yml must not publish from `{wrong}`"

--- a/crates/trios-igla-race/tests/scarab_runtime_invariants.rs
+++ b/crates/trios-igla-race/tests/scarab_runtime_invariants.rs
@@ -134,3 +134,152 @@ fn scarab_refuses_to_start_without_identity_or_db_url() {
         "scarab must accept DATABASE_URL with legacy fallbacks documented"
     );
 }
+
+// -- deployment / image-publish wiring guards --
+//
+// PR #221 fixed `scarab.rs` to ADR-0042 pull-loop semantics, but the
+// merged code never reached Railway because there was no CI path that
+// built and published the scarab image. These guards lock the deploy
+// wiring so that the binary that ships to `ghcr.io/<owner>/sovereign-scarab`
+// is the ADR-0042 `scarab` bin and not a legacy queue worker.
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|p| p.parent())
+        .expect("workspace root")
+        .to_path_buf()
+}
+
+fn scarab_dockerfile() -> String {
+    let path = repo_root()
+        .join("crates")
+        .join("trios-igla-race")
+        .join("Dockerfile.scarab");
+    fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+}
+
+fn sovereign_scarab_workflow() -> String {
+    let path = repo_root()
+        .join(".github")
+        .join("workflows")
+        .join("sovereign-scarab.yml");
+    fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+}
+
+/// `Dockerfile.scarab` must build the ADR-0042 scarab bin from this
+/// crate. If someone re-points it at a legacy bin (`seed_agent`,
+/// `seed_gardener`, `reset_queue`, `debug_queue`, `trios-igla-race`),
+/// the deployed image will run the wrong process and heartbeat stays
+/// at zero — the exact failure mode this PR is fixing.
+#[test]
+fn scarab_dockerfile_builds_adr0042_scarab_bin() {
+    let dockerfile = scarab_dockerfile();
+    assert!(
+        dockerfile.contains("--bin scarab")
+            && dockerfile.contains("-p trios-igla-race"),
+        "Dockerfile.scarab must build `--bin scarab -p trios-igla-race`; \
+         got:\n{dockerfile}"
+    );
+    for legacy in [
+        "--bin seed_agent",
+        "--bin seed_gardener",
+        "--bin reset_queue",
+        "--bin debug_queue",
+        "--bin trios-igla-race",
+        "--bin smoke_agent",
+        "--bin trios-railway-mcp",
+        "--bin seed-agent",
+    ] {
+        assert!(
+            !dockerfile.contains(legacy),
+            "Dockerfile.scarab must NOT build legacy bin `{legacy}` — \
+             ADR-0042 deploy must run src/bin/scarab.rs"
+        );
+    }
+}
+
+/// The runtime stage of `Dockerfile.scarab` must `CMD`/`ENTRYPOINT` the
+/// scarab binary at the conventional `/usr/local/bin/scarab` path.
+/// A regression that points the runtime at a legacy bin (or no CMD at
+/// all, leaving the base image default) would mean the container starts
+/// but never reaches the ADR-0042 pull-loop.
+#[test]
+fn scarab_dockerfile_runtime_invokes_scarab_binary() {
+    let dockerfile = scarab_dockerfile();
+    let has_cmd = dockerfile.contains("CMD [\"/usr/local/bin/scarab\"]")
+        || dockerfile.contains("ENTRYPOINT [\"/usr/local/bin/scarab\"]");
+    assert!(
+        has_cmd,
+        "Dockerfile.scarab runtime stage must CMD or ENTRYPOINT \
+         /usr/local/bin/scarab; got:\n{dockerfile}"
+    );
+    for legacy in [
+        "/usr/local/bin/seed-agent",
+        "/usr/local/bin/seed_agent",
+        "/usr/local/bin/seed_gardener",
+        "/usr/local/bin/trios-igla-race",
+        "/usr/local/bin/trios-railway-mcp",
+        "/usr/local/bin/tri-railway",
+    ] {
+        assert!(
+            !dockerfile.contains(legacy),
+            "Dockerfile.scarab runtime must NOT launch legacy bin `{legacy}` — \
+             scarab fleet must run ADR-0042 pull-loop"
+        );
+    }
+}
+
+/// A publishing workflow must exist so the ADR-0042 scarab image gets
+/// to GHCR for Railway to pull. Without this workflow the code-level
+/// fix in scarab.rs never reaches the deployed process — which is the
+/// exact failure this PR remediates.
+#[test]
+fn sovereign_scarab_publish_workflow_exists_and_targets_scarab_dockerfile() {
+    let wf = sovereign_scarab_workflow();
+    assert!(
+        wf.contains("crates/trios-igla-race/Dockerfile.scarab"),
+        "sovereign-scarab.yml must build crates/trios-igla-race/Dockerfile.scarab; \
+         got:\n{wf}"
+    );
+    assert!(
+        wf.contains("sovereign-scarab"),
+        "sovereign-scarab.yml must publish under the `sovereign-scarab` image name \
+         (matches docs/DEPLOY_SOVEREIGN_SCARAB_V4.md and railway.toml.template)"
+    );
+    // The workflow must NOT reuse the MCP Dockerfile or other legacy
+    // Dockerfiles — that would publish the wrong runtime.
+    for wrong in [
+        "Dockerfile.mcp",
+        "Dockerfile.real-seed-agent",
+    ] {
+        assert!(
+            !wf.contains(wrong),
+            "sovereign-scarab.yml must not publish from `{wrong}`"
+        );
+    }
+}
+
+/// ADR-0042 forbids any Railway-mutation control path from this repo
+/// against scarab services. The publish workflow must never reach for
+/// the Railway GraphQL push API (`variableUpsert`, `serviceInstance*`,
+/// `serviceDelete`) and must never reference a Railway PAT.
+#[test]
+fn sovereign_scarab_workflow_is_read_only_against_railway() {
+    let wf = sovereign_scarab_workflow();
+    for forbidden in [
+        "variableUpsert",
+        "serviceInstanceDeployV2",
+        "serviceInstanceRedeploy",
+        "serviceInstanceUpdate",
+        "serviceDelete",
+        "RAILWAY_TOKEN",
+        "RAILWAY_API_TOKEN",
+    ] {
+        assert!(
+            !wf.contains(forbidden),
+            "sovereign-scarab.yml must not touch Railway control plane (`{forbidden}` \
+             found) — scarab fleet control is SSOT, not Railway API (ADR-0042)"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Add `.github/workflows/sovereign-scarab.yml` that builds `crates/trios-igla-race/Dockerfile.scarab` and publishes `ghcr.io/<owner>/sovereign-scarab:{latest,v4,<sha>,<branch>}`.
- Add four regression guards in `crates/trios-igla-race/tests/scarab_runtime_invariants.rs` proving the deploy/start wiring points at the ADR-0042 scarab runtime, not a legacy queue worker.

## Why

PR #221 merged the ADR-0042 SSOT pull-loop rewrite in `crates/trios-igla-race/src/bin/scarab.rs`, but post-merge SSOT still showed:

- `ssot.scarab_heartbeat`: 0 rows
- `ssot.bpb_samples`: 0 rows in the last 6 hours
- Canary `15a3cb76-…`: `heartbeat_rows=0`, `last_seen=null` after 75 s, 180 s, and 9 cron runs

### Root cause

`docs/DEPLOY_SOVEREIGN_SCARAB_V4.md` and `railway.toml.template` both reference \`ghcr.io/ghashtag/sovereign-scarab:v4\` as the image Railway scarab services pull, and docs state the image is published by \`.github/workflows/sovereign-scarab.yml\` (PR #159). **That workflow does not exist in the repo.** \`Dockerfile.scarab\` lives at \`crates/trios-igla-race/Dockerfile.scarab\` but is never built or pushed by any CI. The root \`railway.json\` points at \`Dockerfile.mcp\` (correct for the MCP service, but no scarab build path).

Net effect: merging the code-level ADR-0042 fix into \`main\` did not change the image that scarab services pull on Railway. Live scarab services continued running stale legacy bytes (or no live process), so heartbeat stayed at 0.

This PR adds the missing image-publish workflow so the ADR-0042 runtime actually ships to GHCR. The Railway scarab services will pick up the new \`:latest\` / \`:v4\` tag on their next pull (which is the SSOT-driven path, not a Railway API push from this repo).

### What this PR does NOT do

- It does **not** touch Railway control plane. No \`variableUpsert\`, no \`serviceInstanceRedeploy\`, no \`serviceDelete\`, no Railway PAT. Scarab control plane remains SSOT-only per ADR-0042.
- It does not modify \`railway.json\` (that's the MCP service and correct as-is).
- It does not delete or weaken any existing guard. The new guards are additive.
- It does not modify \`scarab.rs\` runtime behavior.

## Test plan

- [x] Verified \`Dockerfile.scarab\` already builds \`--bin scarab -p trios-igla-race\` and runs \`/usr/local/bin/scarab\` (manual grep — assertion targets present).
- [x] Verified new workflow references the correct Dockerfile and image name.
- [ ] CI runs new tests:
  - \`scarab_dockerfile_builds_adr0042_scarab_bin\`
  - \`scarab_dockerfile_runtime_invokes_scarab_binary\`
  - \`sovereign_scarab_publish_workflow_exists_and_targets_scarab_dockerfile\`
  - \`sovereign_scarab_workflow_is_read_only_against_railway\`
- [ ] On merge, \`sovereign-scarab\` workflow publishes \`ghcr.io/<owner>/sovereign-scarab:latest\`.
- [ ] After image publish, operator triggers (or waits for) Railway services to pull \`:latest\` / \`:v4\`. Then verify \`ssot.scarab_heartbeat\` row count > 0 and \`canary_last_seen\` becomes non-null.

## Remaining blockers (out of scope for this PR)

1. **Railway service image tag.** Each scarab service on Railway must be pointed at the freshly published \`ghcr.io/<owner>/sovereign-scarab:latest\` (or \`:v4\`). If services were previously configured with a different image source (e.g. a build target, or a stale tag), an operator action is needed in the Railway UI / CLI to switch the source. ADR-0042 forbids doing this via Railway API from this repo.
2. **Environment variables on each service.** Per \`docs/DEPLOY_SOVEREIGN_SCARAB_V4.md\` §2, each service needs \`DATABASE_URL\` pointing at Trinity SSOT, plus optional \`POLL_INTERVAL_MS\` / \`HEARTBEAT_INTERVAL_S\` / \`RUST_LOG\`. \`RAILWAY_SERVICE_ID\` is injected by Railway. Setting env vars is operator-tier (not in this repo's automation surface).
3. **Canary service identity.** If \`service_id=15a3cb76-522a-4f5b-a4f4-7eb6888f6de7\` is not actually the Railway-assigned \`RAILWAY_SERVICE_ID\` of any deployed service, the canary will keep heart-beating against a service_id that no live process recognises. Operator needs to confirm SSOT \`service_id\` ↔ Railway \`RAILWAY_SERVICE_ID\` parity.

Anchor: phi^2 + phi^-2 = 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)