### PR TITLE
fix(scarab): bump Dockerfile.scarab to rust:1.90 for edition2024 deps

### DIFF
--- a/crates/trios-igla-race/Dockerfile.scarab
+++ b/crates/trios-igla-race/Dockerfile.scarab
@@ -1,20 +1,36 @@
 # Scarab worker — stateless fungible pool.
 # Built from crates/trios-igla-race, single binary.
 #
+# ADR-0042 SSOT pull-loop runtime (src/bin/scarab.rs).
+#
 # Required:
-#   RAILWAY_POSTGRES_URL=postgres://...
-#   (legacy NEON_DATABASE_URL accepted as fallback per L-NEON-RENAME)
+#   DATABASE_URL=postgres://...
+#   (legacy RAILWAY_POSTGRES_URL / NEON_DATABASE_URL accepted as fallback)
+#   RAILWAY_SERVICE_ID (Railway injects automatically; SCARAB_SERVICE_ID
+#                       accepted as manual override for local runs)
 # Optional (log label, no routing effect):
 #   SCARAB_ACCOUNT=acc0
+#
+# Toolchain note: tokio-postgres 0.7.17 declares `edition = "2024"`, which
+# requires Rust >= 1.85. We pin `rust:1.90-slim-bookworm` to match
+# Dockerfile.mcp and stay one minor below `rust:1.91-slim` used by
+# Dockerfile.real-seed-agent.
 
-FROM rust:1.82-slim AS builder
+FROM rust:1.90-slim-bookworm AS builder
+
+ENV CARGO_TERM_COLOR=always \
+    DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
-    apt-get install -y pkg-config libssl-dev && \
+    apt-get install -y --no-install-recommends \
+        pkg-config \
+        libssl-dev \
+        ca-certificates \
+        build-essential && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /build
-# Copy full workspace so crate deps resolve
+# Copy full workspace so crate deps resolve.
 COPY . .
 
 RUN cargo build --release --bin scarab -p trios-igla-race
@@ -23,7 +39,9 @@ RUN cargo build --release --bin scarab -p trios-igla-race
 FROM debian:bookworm-slim
 
 RUN apt-get update && \
-    apt-get install -y ca-certificates libssl3 && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        libssl3 && \
     rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /build/target/release/scarab /usr/local/bin/scarab

--- a/crates/trios-igla-race/tests/scarab_runtime_invariants.rs
+++ b/crates/trios-igla-race/tests/scarab_runtime_invariants.rs
@@ -258,7 +258,7 @@ fn scarab_dockerfile_rust_toolchain_supports_edition2024() {
         found_rust_from = true;
         // `1.90-slim-bookworm` -> `1.90` -> (1, 90).
         let version_token = version_part
-            .split(|c: char| c == '-' || c == '@')
+            .split(['-', '@'])
             .next()
             .unwrap_or(version_part);
         let mut parts = version_token.split('.');

--- a/crates/trios-igla-race/tests/scarab_runtime_invariants.rs
+++ b/crates/trios-igla-race/tests/scarab_runtime_invariants.rs
@@ -229,6 +229,61 @@ fn scarab_dockerfile_runtime_invokes_scarab_binary() {
     }
 }
 
+/// `Dockerfile.scarab`'s builder stage must use a Rust base image new
+/// enough to compile the workspace's transitive deps. tokio-postgres
+/// 0.7.17 (and its transitive crates) declare `edition = "2024"`, which
+/// the compiler only accepts on Rust >= 1.85. A regression to an older
+/// image (e.g. `rust:1.82-slim`, the original toolchain) breaks the
+/// sovereign-scarab GHCR publish workflow and the ADR-0042 runtime
+/// never reaches Railway. We scan for the version embedded in `FROM
+/// rust:<MAJOR>.<MINOR>...` and reject anything below 1.85.
+#[test]
+fn scarab_dockerfile_rust_toolchain_supports_edition2024() {
+    const MIN_MAJOR: u32 = 1;
+    const MIN_MINOR: u32 = 85;
+    let dockerfile = scarab_dockerfile();
+    let mut found_rust_from = false;
+    for line in dockerfile.lines() {
+        let trimmed = line.trim_start();
+        // Match lines like `FROM rust:1.90-slim-bookworm AS builder`.
+        let Some(rest) = trimmed.strip_prefix("FROM ") else {
+            continue;
+        };
+        let Some(tag) = rest.split_whitespace().next() else {
+            continue;
+        };
+        let Some(version_part) = tag.strip_prefix("rust:") else {
+            continue;
+        };
+        found_rust_from = true;
+        // `1.90-slim-bookworm` -> `1.90` -> (1, 90).
+        let version_token = version_part
+            .split(|c: char| c == '-' || c == '@')
+            .next()
+            .unwrap_or(version_part);
+        let mut parts = version_token.split('.');
+        let major: u32 = parts
+            .next()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or_else(|| panic!("cannot parse rust major from `{tag}`"));
+        let minor: u32 = parts
+            .next()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or_else(|| panic!("cannot parse rust minor from `{tag}`"));
+        assert!(
+            (major, minor) >= (MIN_MAJOR, MIN_MINOR),
+            "Dockerfile.scarab builder uses `rust:{version_token}` but workspace \
+             transitive deps (tokio-postgres 0.7.17) require Rust >= \
+             {MIN_MAJOR}.{MIN_MINOR} for edition2024 support. Bump the FROM line."
+        );
+    }
+    assert!(
+        found_rust_from,
+        "Dockerfile.scarab must declare a `FROM rust:<version>` builder stage; \
+         got:\n{dockerfile}"
+    );
+}
+
 /// A publishing workflow must exist so the ADR-0042 scarab image gets
 /// to GHCR for Railway to pull. Without this workflow the code-level
 /// fix in scarab.rs never reaches the deployed process — which is the


### PR DESCRIPTION
## Summary

- Bump `crates/trios-igla-race/Dockerfile.scarab` builder from `rust:1.82-slim` to `rust:1.90-slim-bookworm`.
- Add regression guard `scarab_dockerfile_rust_toolchain_supports_edition2024` so the toolchain can't silently regress below the workspace MSRV floor again.

## Why

PR #222 wired up the `sovereign-scarab` publish workflow. Its first run on `main` failed in:

```
RUN cargo build --release --bin scarab -p trios-igla-race
  ↳ error: tokio-postgres 0.7.17 requires Cargo feature edition2024
            cargo 1.82.0 does not understand edition = "2024"
```

Edition 2024 was stabilized in Rust 1.85. The Dockerfile.scarab builder was pinned at `rust:1.82-slim`, three minor versions below the floor.

### Fix

Bump the builder to `rust:1.90-slim-bookworm`:

- Matches `Dockerfile.mcp` (same base image), so the two GHA-cached layer trees share a Rust toolchain.
- Stays one minor below `Dockerfile.real-seed-agent` (`rust:1.91-slim`), which is intentional — `Dockerfile.real-seed-agent` builds against an external trainer image and tends to lead the toolchain.
- Aligns `apt-get install` to `--no-install-recommends` plus `build-essential` and `ca-certificates`, matching `Dockerfile.mcp`'s pattern.

### Regression guard

`crates/trios-igla-race/tests/scarab_runtime_invariants.rs` now contains `scarab_dockerfile_rust_toolchain_supports_edition2024`: parses the `FROM rust:<MAJOR>.<MINOR>...` line and asserts `(MAJOR, MINOR) >= (1, 85)`. The test panics with a clear error if someone re-pins the Dockerfile to a too-old Rust toolchain.

### What this PR does NOT do

- No changes to `scarab.rs` runtime behavior.
- No Railway control-plane interaction (no `variableUpsert`, no `serviceInstance*`, no `serviceDelete`, no Railway PAT). ADR-0042 SSOT pull-loop invariants preserved.
- No dependency pinning / downgrade. Bumping the toolchain is safer than pinning `tokio-postgres` to an older release, since other workspace crates may also need newer editions.
- Does not modify the four existing deploy-wiring guards from PR #222.

## Test plan

- [x] Verified `Dockerfile.scarab` now uses `FROM rust:1.90-slim-bookworm AS builder`.
- [x] Verified new regression guard parses `1.90` correctly and the assertion `(1, 90) >= (1, 85)` holds.
- [ ] CI runs new test (and all four existing deploy-wiring guards) on this branch.
- [ ] On merge, `sovereign-scarab` workflow runs on `main` and successfully publishes `ghcr.io/<owner>/sovereign-scarab:latest`.

## Remaining blockers (unchanged from PR #222)

1. After the image is published, each Railway scarab service must be configured to pull `ghcr.io/<owner>/sovereign-scarab:latest` (or `:v4`). Operator action, per ADR-0042.
2. Per-service `DATABASE_URL` env must point at Trinity SSOT.
3. SSOT `service_id` ↔ Railway `RAILWAY_SERVICE_ID` parity for the canary `15a3cb76-…`.
4. GHCR pull credentials if the package is private.

Anchor: phi^2 + phi^-2 = 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)