### PR TITLE
fix(scarab): link GHCR package to repo via OCI image.source label

### DIFF
--- a/crates/trios-igla-race/Dockerfile.scarab
+++ b/crates/trios-igla-race/Dockerfile.scarab
@@ -38,6 +38,17 @@ RUN cargo build --release --bin scarab -p trios-igla-race
 # ── runtime ───────────────────────────────────────────────────────────────────
 FROM debian:bookworm-slim
 
+# OCI labels: GitHub uses `org.opencontainers.image.source` to link the
+# published GHCR package to the source repository on first push. Without
+# this label, pushing a brand-new package under a user namespace from a
+# workflow with `permissions: packages: write` still fails with
+# `permission_denied: write_package`, because GHCR cannot infer which
+# repo owns the package and therefore which `GITHUB_TOKEN` is allowed to
+# write to it (docs.github.com/.../working-with-the-container-registry).
+LABEL org.opencontainers.image.source="https://github.com/gHashTag/trios-railway" \
+      org.opencontainers.image.url="https://github.com/gHashTag/trios-railway" \
+      org.opencontainers.image.description="Sovereign Scarab — ADR-0042 SSOT pull-loop runtime"
+
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         ca-certificates \

--- a/crates/trios-igla-race/tests/scarab_runtime_invariants.rs
+++ b/crates/trios-igla-race/tests/scarab_runtime_invariants.rs
@@ -229,6 +229,38 @@ fn scarab_dockerfile_runtime_invokes_scarab_binary() {
     }
 }
 
+/// `Dockerfile.scarab` must declare `org.opencontainers.image.source`
+/// pointing at the source repository. GitHub uses this OCI label to
+/// auto-link the GHCR package to the repo on first push; without it,
+/// a brand-new package under a user namespace gets rejected with
+/// `permission_denied: write_package` even when the workflow declares
+/// `permissions: packages: write` — because GHCR cannot infer which
+/// repo owns the package and therefore which `GITHUB_TOKEN` is allowed
+/// to write to it.
+///
+/// Ref: docs.github.com/en/packages/working-with-a-github-packages-registry/
+///      working-with-the-container-registry — "Adding a description to
+///      your container".
+#[test]
+fn scarab_dockerfile_declares_oci_image_source_label() {
+    let dockerfile = scarab_dockerfile();
+    assert!(
+        dockerfile.contains("org.opencontainers.image.source"),
+        "Dockerfile.scarab must declare `org.opencontainers.image.source` so \
+         GitHub auto-links the GHCR package to the source repository on first \
+         push; without it GHCR rejects with `permission_denied: write_package` \
+         on a brand-new user-namespace package."
+    );
+    // Catch typos / wrong-repo regressions: the label must point at this
+    // repo, not a fork or unrelated mirror. Match either the literal
+    // canonical URL or the case-insensitive ghashtag/trios-railway pair.
+    let lower = dockerfile.to_lowercase();
+    assert!(
+        lower.contains("github.com/ghashtag/trios-railway"),
+        "Dockerfile.scarab `image.source` must point at github.com/gHashTag/trios-railway"
+    );
+}
+
 /// `Dockerfile.scarab`'s builder stage must use a Rust base image new
 /// enough to compile the workspace's transitive deps. tokio-postgres
 /// 0.7.17 (and its transitive crates) declare `edition = "2024"`, which


### PR DESCRIPTION
## Summary

- Add `LABEL org.opencontainers.image.source` (+ `image.url`, `image.description`) to the runtime stage of `crates/trios-igla-race/Dockerfile.scarab`, pointing at `https://github.com/gHashTag/trios-railway`.
- Add regression guard `scarab_dockerfile_declares_oci_image_source_label`.

## Why

PR #224 disabled provenance/sbom but the same `permission_denied: write_package` denial recurred on [run 26019265929](https://github.com/gHashTag/trios-railway/actions/runs/26019265929) — this time directly on the main manifest push.

### Evidence-based diagnosis

1. `gh api repos/gHashTag/trios-railway/actions/permissions/workflow` returns `default_workflow_permissions: read`. Per [GitHub docs on controlling `GITHUB_TOKEN`](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token), the workflow YAML *can* override this default with `permissions: packages: write` (which the workflow declares at both top-level and job-level). So the repo-default `read` is **not** the blocker on its own.
2. Anonymous GHCR manifest probe:
   - `ghcr.io/v2/ghashtag/trios-railway-mcp/manifests/latest` → 200 (package exists; `docker-mcp.yml` updates it fine)
   - `ghcr.io/v2/ghashtag/sovereign-scarab/manifests/latest` → 404 MANIFEST_UNKNOWN (never created)
3. The token line `[auth] ghashtag/sovereign-scarab:pull,push token for ghcr.io DONE` shows GHCR did issue a push-scoped token. The denial is from the registry, not from auth.

This is the [documented first-push trap](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry): on creation of a brand-new package under a user namespace, GHCR cannot infer which repo owns the package, so it doesn't know which `GITHUB_TOKEN` should be allowed to write to it. The result is `write_package` denied even with `packages: write`.

### The fix

[GitHub Docs explicitly recommends](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#labelling-container-images):

> "To connect a repository when publishing an image from the command line, and to ensure your `GITHUB_TOKEN` has appropriate permissions when using a GitHub Actions workflow, add the label `org.opencontainers.image.source` to your Dockerfile."

So this PR adds:

```dockerfile
LABEL org.opencontainers.image.source="https://github.com/gHashTag/trios-railway" \
      org.opencontainers.image.url="https://github.com/gHashTag/trios-railway" \
      org.opencontainers.image.description="Sovereign Scarab — ADR-0042 SSOT pull-loop runtime"
```

This is purely repo-side. No GitHub UI/API settings need to change. The first push will now auto-link the new package to this repo.

### Regression guard

`scarab_dockerfile_declares_oci_image_source_label`:
- requires `org.opencontainers.image.source` to be present in `Dockerfile.scarab`,
- requires the value to point at `github.com/gHashTag/trios-railway` (case-insensitive).

### What this PR does NOT do

- No changes to `scarab.rs` runtime behavior.
- No Railway control-plane interaction (no `variableUpsert`, no `serviceInstance*`, no `serviceDelete`, no Railway PAT).
- ADR-0042 SSOT pull-loop invariants preserved.
- Does not modify the existing seven deploy-wiring / toolchain / publish-permission guards.

## Test plan

- [x] Verified labels present in `Dockerfile.scarab` runtime stage.
- [x] Manual grep confirms case-insensitive match `github.com/ghashtag/trios-railway` succeeds.
- [ ] CI runs new guard plus all seven existing guards on this branch.
- [ ] On merge, `sovereign-scarab` workflow run on `main` successfully creates `ghcr.io/<owner>/sovereign-scarab:latest`, linked to this repo.

## Fallback if this still doesn't unstick the publish

If after this PR merges the first run on `main` *still* hits `write_package`, the only remaining cause is an out-of-band setting that this repo cannot affect from code. The operator must take **one** of:

1. **Manual link via Package settings** (preferred, ~30 seconds):
   - Navigate to `https://github.com/users/gHashTag/packages/container/sovereign-scarab` (the package will exist after one failed-but-creating push, even if it shows as untagged).
   - "Package settings" → "Manage Actions access" → "Add repository" → select `gHashTag/trios-railway` → role: **Write**.
   - Re-run the workflow.
2. **Bootstrap-push from CLI with PAT** (one-time):
   - Generate a PAT with `write:packages` scope from `https://github.com/settings/tokens`.
   - Locally:
     ```
     echo "<PAT>" | docker login ghcr.io -u gHashTag --password-stdin
     docker pull ghcr.io/ghashtag/trios-railway-mcp:latest
     docker tag ghcr.io/ghashtag/trios-railway-mcp:latest ghcr.io/ghashtag/sovereign-scarab:bootstrap
     docker push ghcr.io/ghashtag/sovereign-scarab:bootstrap
     ```
   - This creates the package; on the next workflow run, the image.source label auto-links it.
3. **Repo-default `default_workflow_permissions` → `write`**:
   ```
   gh api -X PUT repos/gHashTag/trios-railway/actions/permissions/workflow \
     -f default_workflow_permissions=write -F can_approve_pull_request_reviews=false
   ```
   This is broader than necessary (workflows currently rely on explicit `permissions:` blocks) and is the least-preferred fallback.

None of these require Railway API/PAT/variableUpsert/redeploy/delete. ADR-0042 invariants are unchanged.

## Remaining blockers (unchanged from PR #222–#224)

1. Once `sovereign-scarab` publishes, each Railway service must be pointed at `ghcr.io/<owner>/sovereign-scarab:latest` (operator action per ADR-0042 — no Railway API push from this repo).
2. Per-service `DATABASE_URL` env on Trinity SSOT.
3. SSOT `service_id` ↔ Railway `RAILWAY_SERVICE_ID` parity for canary `15a3cb76-…`.

Anchor: phi^2 + phi^-2 = 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)