### PR TITLE
fix(scarab): use GHCR_TRAINER_PAT for sovereign-scarab GHCR login

### DIFF
--- a/.github/workflows/sovereign-scarab.yml
+++ b/.github/workflows/sovereign-scarab.yml
@@ -47,11 +47,23 @@ jobs:
 
       - uses: docker/setup-buildx-action@v3
 
+      # GHCR login uses the same cross-repo PAT the trainer image publish
+      # uses (`docker-trainer.yml`), because the default `GITHUB_TOKEN` was
+      # observed to fail brand-new package creation under the user namespace
+      # `ghashtag/*` with `permission_denied: write_package` even after
+      # `packages: write` was granted and the OCI `image.source` label was
+      # added (PRs #223-#225). The trainer publish has been pushing to
+      # `ghcr.io/ghashtag/trios-trainer-igla` successfully on the same
+      # cadence using this PAT, so reusing it is the minimal unblock.
+      #
+      # The PAT is read from the repo secret `GHCR_TRAINER_PAT` and never
+      # echoed. This change is GHCR-side only: scarab control plane stays
+      # SSOT (ADR-0042) — no Railway API/PAT/variableUpsert/redeploy.
       - uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: gHashTag
+          password: ${{ secrets.GHCR_TRAINER_PAT }}
 
       - name: Compute tags
         id: tags

--- a/.github/workflows/sovereign-scarab.yml
+++ b/.github/workflows/sovereign-scarab.yml
@@ -58,7 +58,7 @@ jobs:
       #
       # The PAT is read from the repo secret `GHCR_TRAINER_PAT` and never
       # echoed. This change is GHCR-side only: scarab control plane stays
-      # SSOT (ADR-0042) — no Railway API/PAT/variableUpsert/redeploy.
+      # SSOT (ADR-0042) — no Railway control-plane mutations are added.
       - uses: docker/login-action@v3
         with:
           registry: ghcr.io

--- a/crates/trios-igla-race/tests/scarab_runtime_invariants.rs
+++ b/crates/trios-igla-race/tests/scarab_runtime_invariants.rs
@@ -467,8 +467,7 @@ fn trainer_publish_workflow_anchors_ghcr_trainer_pat_credential() {
         .join(".github")
         .join("workflows")
         .join("docker-trainer.yml");
-    let wf = fs::read_to_string(&path)
-        .unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    let wf = fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
     assert!(
         wf.contains("secrets.GHCR_TRAINER_PAT"),
         "docker-trainer.yml is the canonical anchor for the GHCR_TRAINER_PAT \

--- a/crates/trios-igla-race/tests/scarab_runtime_invariants.rs
+++ b/crates/trios-igla-race/tests/scarab_runtime_invariants.rs
@@ -428,3 +428,56 @@ fn sovereign_scarab_workflow_declares_ghcr_publish_permissions() {
          to avoid GHCR write_package races on first publish"
     );
 }
+
+/// The sovereign-scarab GHCR login step must use the same cross-repo PAT
+/// that the proven-good trainer publish workflow uses
+/// (`GHCR_TRAINER_PAT`). The default `GITHUB_TOKEN` was observed to fail
+/// brand-new package creation under the `ghashtag/*` user namespace with
+/// `permission_denied: write_package` even after `packages: write` was
+/// granted and the OCI `image.source` label was added (workflow run
+/// 26019864970, PRs #223-#225). The trainer publish has been pushing to
+/// `ghcr.io/ghashtag/trios-trainer-igla` successfully against this PAT,
+/// so reusing it is the minimal unblock. This guard locks the credential
+/// in so a future refactor doesn't silently regress back to the failing
+/// `GITHUB_TOKEN` path.
+#[test]
+fn sovereign_scarab_workflow_uses_ghcr_trainer_pat_for_login() {
+    let wf = sovereign_scarab_workflow();
+    assert!(
+        wf.contains("secrets.GHCR_TRAINER_PAT"),
+        "sovereign-scarab.yml must use `secrets.GHCR_TRAINER_PAT` for the \
+         GHCR login password (same proven-good credential as docker-trainer.yml)"
+    );
+    assert!(
+        !wf.contains("secrets.GITHUB_TOKEN"),
+        "sovereign-scarab.yml must NOT use `secrets.GITHUB_TOKEN` for GHCR \
+         login — that path was observed to fail with `permission_denied: \
+         write_package` on the user-namespace package"
+    );
+}
+
+/// The trainer publish workflow (`docker-trainer.yml`) must continue to
+/// own the `GHCR_TRAINER_PAT` credential under the same login shape we
+/// are reusing in `sovereign-scarab.yml`. If someone rotates the trainer
+/// publish off this PAT, the scarab publish should be re-audited at the
+/// same time. This is a text-level cross-workflow consistency guard.
+#[test]
+fn trainer_publish_workflow_anchors_ghcr_trainer_pat_credential() {
+    let path = repo_root()
+        .join(".github")
+        .join("workflows")
+        .join("docker-trainer.yml");
+    let wf = fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    assert!(
+        wf.contains("secrets.GHCR_TRAINER_PAT"),
+        "docker-trainer.yml is the canonical anchor for the GHCR_TRAINER_PAT \
+         credential reused by sovereign-scarab.yml; if you removed the PAT \
+         here, re-audit sovereign-scarab.yml at the same time"
+    );
+    assert!(
+        wf.contains("registry: ghcr.io"),
+        "docker-trainer.yml must keep targeting ghcr.io for the credential \
+         anchor to remain valid"
+    );
+}


### PR DESCRIPTION
## Summary

- Switches the `sovereign-scarab` GHCR login step to the cross-repo PAT `secrets.GHCR_TRAINER_PAT` — the same proven-good credential the trainer publish workflow (`docker-trainer.yml`) uses to push `ghcr.io/ghashtag/trios-trainer-igla` on the same `ghashtag/*` user namespace.
- The merged `GITHUB_TOKEN` login still fails on first push of `ghcr.io/ghashtag/sovereign-scarab` with `permission_denied: write_package` (workflow run 26019864970) even after repo default workflow permissions were set to write and the OCI `image.source` label was added (PRs #223-#225). Reusing the trainer PAT is the minimal unblock — GHCR-side only.
- Adds text-level regression guards in `crates/trios-igla-race/tests/scarab_runtime_invariants.rs`:
  - `sovereign-scarab.yml` must use `secrets.GHCR_TRAINER_PAT`
  - `sovereign-scarab.yml` must NOT use `secrets.GITHUB_TOKEN`
  - `docker-trainer.yml` remains the canonical PAT credential anchor

## Not changed (ADR-0042 invariants preserved)

- No Railway API / PAT / `variableUpsert` / `serviceInstanceRedeploy` / `serviceDelete` introduced. Scarab control plane is still SSOT (`ssot.scarab_strategy`), not Railway GraphQL.
- Workflow still builds `crates/trios-igla-race/Dockerfile.scarab`, which still builds `--bin scarab -p trios-igla-race`.
- `provenance: false` / `sbom: false` / OCI `image.source` label / both-level `packages: write` declarations all preserved (existing guards keep them locked).

## Testing

- [x] YAML parses cleanly (`python3 -c "import yaml; yaml.safe_load(...)"`).
- [x] No `secrets.GITHUB_TOKEN` references remain (`grep`).
- [ ] CI runs `scarab_runtime_invariants` integration suite — new guards `sovereign_scarab_workflow_uses_ghcr_trainer_pat_for_login` and `trainer_publish_workflow_anchors_ghcr_trainer_pat_credential` must pass alongside the existing suite.
- [ ] `sovereign-scarab` workflow run on `main` after merge pushes `ghcr.io/ghashtag/sovereign-scarab:latest` without `permission_denied: write_package`.

Anchor: `phi^2 + phi^-2 = 3`.
Agent: GENERAL