### PR TITLE
feat(ci): daily scheduled rebuild for sovereign-scarab image

### DIFF
--- a/.github/workflows/sovereign-scarab.yml
+++ b/.github/workflows/sovereign-scarab.yml
@@ -58,6 +58,8 @@ on:
       - "Cargo.lock"
       - ".github/workflows/sovereign-scarab.yml"
   workflow_dispatch:
+  schedule:
+    - cron: "0 6 * * *"  # Daily at 06:00 UTC — ensures fresh image even without code changes
 
 permissions:
   contents: read


### PR DESCRIPTION
## Problem

The sovereign-scarab workflow only triggers on:
1. Push to main with matching paths (code changes)
2. Manual `workflow_dispatch`

This means the scarab image can become **stale** when trainer experiments produce new working combinations (e.g., `fp80×muon`) but `Dockerfile.scarab` and `bin/scarab.rs` are unchanged.

## Solution

Add daily cron schedule (06:00 UTC) to rebuild the image automatically.

### Changes
```yaml
schedule:
  - cron: "0 6 * * *"  # Daily at 06:00 UTC
```

### Trigger matrix (after this PR)
| Trigger | When | Use case |
|---------|------|----------|
| `push` | Code change in relevant paths | Development iteration |
| `workflow_dispatch` | Manual operator action | Emergency/debug rebuild |
| `schedule` | Daily at 06:00 UTC | **Fresh image with latest base + dependencies** |

### Unchanged
- No Railway API calls
- No PAT usage beyond existing `GHCR_TRAINER_PAT`
- Same Dockerfile.scarab, same tags
- ADR-0042 SSOT architecture intact

---
Anchor: phi^2 + phi^-2 = 3.